### PR TITLE
ROX-2715 - Obtain certificates with LetsEncrypt

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:5e280b2fb5f4ba98c5e27e430ecd64e868c78876e011c8f826839bda848cf5a6"
   name = "github.com/golang/protobuf"
   packages = [
@@ -42,6 +50,17 @@
   pruneopts = "UT"
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:cb823a5f7777276059b25eaadda6a12892f3beb6d0deee01df0d8f8692ffcc82"
+  name = "golang.org/x/crypto"
+  packages = [
+    "acme",
+    "acme/autocert",
+  ]
+  pruneopts = "UT"
+  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
 [[projects]]
   branch = "master"
@@ -158,12 +177,14 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/BurntSushi/toml",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
     "github.com/pkg/errors",
+    "golang.org/x/crypto/acme/autocert",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,3 +21,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/BurntSushi/toml"
+  version = "0.3.1"

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
+)
+
+type Config struct {
+	Server ServerConfig `toml:"server"`
+}
+
+type ServerConfig struct {
+	GRPC     string `toml:"grpc"`
+	HTTP     string `toml:"http"`
+	HTTPS    string `toml:"https"`
+	Domain   string `toml:"domain"`
+	CertFile string `toml:"cert"`
+	KeyFile  string `toml:"key"`
+}
+
+func Load(filename string) (*Config, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read config file %q", filename)
+	}
+
+	var cfg Config
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to decode toml")
+	}
+
+	return &cfg, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,16 +5,19 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
+	"github.com/stackrox/infra/config"
 	"github.com/stackrox/infra/service"
+	"golang.org/x/crypto/acme/autocert"
 	"google.golang.org/grpc"
 )
 
 // RunGRPCServer runs the gRPC service.
-func RunGRPCServer(apiServices []service.APIService, grpcAddress string) (func(), <-chan error, error) {
-	listen, err := net.Listen("tcp", grpcAddress)
+func RunGRPCServer(apiServices []service.APIService, cfg *config.Config) (func(), <-chan error, error) {
+	listen, err := net.Listen("tcp", cfg.Server.GRPC)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -37,7 +40,7 @@ func RunGRPCServer(apiServices []service.APIService, grpcAddress string) (func()
 	}
 
 	go func() {
-		log.Printf("starting gRPC server on %s", grpcAddress)
+		log.Printf("starting gRPC server on %s", cfg.Server.GRPC)
 		if err := server.Serve(listen); err != nil {
 			errch <- err
 		}
@@ -47,16 +50,15 @@ func RunGRPCServer(apiServices []service.APIService, grpcAddress string) (func()
 }
 
 // RunHTTPServer runs the HTTP/REST gateway
-func RunHTTPServer(apiServices []service.APIService, httpAddress string, grpcAddress string) (func(), <-chan error, error) {
+func RunHTTPServer(apiServices []service.APIService, cfg *config.Config) (func(), <-chan error, error) {
 	// Register the HTTP/gRPC gateway service.
 	ctx := context.Background()
-	conn, err := grpc.Dial(grpcAddress, grpc.WithInsecure())
+	conn, err := grpc.Dial(cfg.Server.GRPC, grpc.WithInsecure())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "dialing GRPC")
 	}
 
-	mux := http.NewServeMux()
-
+	// Register each service
 	gwMux := runtime.NewServeMux()
 	for _, apiSvc := range apiServices {
 		if err := apiSvc.RegisterServiceHandler(ctx, gwMux, conn); err != nil {
@@ -64,28 +66,141 @@ func RunHTTPServer(apiServices []service.APIService, httpAddress string, grpcAdd
 		}
 	}
 
+	mux := http.NewServeMux()
 	mux.Handle("/v1/", gwMux)
 
-	srv := &http.Server{
-		Addr:    httpAddress,
-		Handler: mux,
-	}
+	shutdown, errch := startHTTP(ctx, mux, cfg)
+	return shutdown, errch, nil
+}
 
+func startHTTP(ctx context.Context, handler http.Handler, cfg *config.Config) (func(), <-chan error) {
 	// errch is a channel of size 1 which will receive the (only) error
 	// returned by the HTTP server.
 	errch := make(chan error, 1)
 
-	shutdown := func() {
-		log.Print("shutting down HTTP server")
-		srv.Shutdown(ctx)
+	switch {
+	case cfg.Server.CertFile != "" && cfg.Server.KeyFile != "":
+		// If a cert and key files are configured, start both the http and https servers.
+		log.Print("starting HTTP+HTTPS server in local certificate mode")
+
+		httpServer := http.Server{
+			Addr:    cfg.Server.HTTP,
+			Handler: handlerRedirectToHTTPS(cfg.Server.HTTPS),
+		}
+
+		httpsServer := http.Server{
+			Addr:    cfg.Server.HTTPS,
+			Handler: handler,
+		}
+
+		shutdown := func() {
+			log.Print("shutting down HTTP server")
+			httpServer.Shutdown(ctx)
+			log.Print("shutting down HTTPS server")
+			httpsServer.Shutdown(ctx)
+		}
+
+		go func() {
+			log.Printf("starting HTTP server on %s", httpServer.Addr)
+			if err := httpServer.ListenAndServe(); err != nil {
+				errch <- err
+			}
+		}()
+
+		go func() {
+			log.Printf("starting HTTPS server on %s", httpsServer.Addr)
+			if err := httpsServer.ListenAndServeTLS(cfg.Server.CertFile, cfg.Server.KeyFile); err != nil {
+				errch <- err
+			}
+		}()
+
+		return shutdown, errch
+
+	case cfg.Server.HTTPS != "" && cfg.Server.Domain != "":
+		// If https and a domain is configured, start both the http and https servers with Let’s Encrypt.
+		log.Print("starting HTTP+HTTPS server in Let’s Encrypt mode")
+
+		certManager := autocert.Manager{
+			Cache:      autocert.DirCache("."),
+			HostPolicy: autocert.HostWhitelist(cfg.Server.Domain),
+			Prompt:     autocert.AcceptTOS,
+		}
+
+		httpServer := http.Server{
+			Addr:    cfg.Server.HTTP,
+			Handler: certManager.HTTPHandler(nil),
+		}
+
+		httpsServer := http.Server{
+			Addr:      cfg.Server.HTTPS,
+			Handler:   handler,
+			TLSConfig: certManager.TLSConfig(),
+		}
+
+		shutdown := func() {
+			log.Print("shutting down HTTP server")
+			httpServer.Shutdown(ctx)
+			log.Print("shutting down HTTPS server")
+			httpsServer.Shutdown(ctx)
+		}
+
+		go func() {
+			log.Printf("starting HTTP server on %s", httpServer.Addr)
+			if err := httpServer.ListenAndServe(); err != nil {
+				errch <- err
+			}
+		}()
+
+		go func() {
+			log.Printf("starting HTTPS server on %s (%s)", httpsServer.Addr, cfg.Server.Domain)
+			if err := httpsServer.ListenAndServeTLS("", ""); err != nil {
+				errch <- err
+			}
+		}()
+
+		return shutdown, errch
+
+	default:
+		// Otherwise, only start the http server.
+		log.Print("Starting HTTP server only")
+
+		httpServer := http.Server{
+			Addr:    cfg.Server.HTTP,
+			Handler: handler,
+		}
+
+		shutdown := func() {
+			log.Print("shutting down HTTP server")
+			httpServer.Shutdown(ctx)
+		}
+
+		go func() {
+			log.Printf("starting HTTP server on %s", httpServer.Addr)
+			if err := httpServer.ListenAndServe(); err != nil {
+				errch <- err
+			}
+		}()
+
+		return shutdown, errch
+	}
+}
+
+// handlerRedirectToHTTPS returns a http.Handler that redirects requests to use HTTPS.
+func handlerRedirectToHTTPS(httpsEndpoint string) http.Handler {
+	httpsPort := "443"
+	chunks := strings.SplitN(httpsEndpoint, ":", 2)
+	if len(chunks) == 2 {
+		httpsPort = chunks[1]
 	}
 
-	go func() {
-		log.Printf("starting HTTP server on %s", httpAddress)
-		if err := srv.ListenAndServe(); err != nil {
-			errch <- err
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			http.Error(w, "Use HTTPS", http.StatusBadRequest)
+			return
 		}
-	}()
 
-	return shutdown, errch, nil
+		host := strings.SplitN(r.Host, ":", 2)[0]
+		target := "https://" + host + ":" + httpsPort + r.URL.RequestURI()
+		http.Redirect(w, r, target, http.StatusFound)
+	})
 }


### PR DESCRIPTION
- Simple server configuration
- Obtain real certs with autocert
- HTTP only mode:

```toml
[server]
grpc   = "localhost:9001"
http   = "0.0.0.0:80"
```

- HTTP+HTTPS with local certs mode:
```toml
[server]
grpc   = "localhost:9001"
http   = "0.0.0.0:80"
cert   = "tls/cert.pem"
key    = "tls/key.pem"
```

- HTTP+HTTPS with Let’s Encrypt mode:
```toml
[server]
grpc   = "localhost:9001"
http   = "0.0.0.0:80"
https  = "0.0.0.0:443"
domain = "test1.demo.stackrox.com"
```