### PR TITLE
ROX-2723 - Serve static resources

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Config struct {
-	Server ServerConfig `toml:"server"`
+	Server  ServerConfig  `toml:"server"`
+	Storage StorageConfig `toml:"storage"`
 }
 
 type ServerConfig struct {
@@ -18,6 +19,11 @@ type ServerConfig struct {
 	Domain   string `toml:"domain"`
 	CertFile string `toml:"cert"`
 	KeyFile  string `toml:"key"`
+}
+
+type StorageConfig struct {
+	CertDir   string `toml:"certs"`
+	StaticDir string `toml:"static"`
 }
 
 func Load(filename string) (*Config, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,7 @@ func RunHTTPServer(apiServices []service.APIService, cfg *config.Config) (func()
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/", gwMux)
+	mux.Handle("/", http.FileServer(http.Dir(cfg.Storage.StaticDir)))
 
 	shutdown, errch := startHTTP(ctx, mux, cfg)
 	return shutdown, errch, nil
@@ -121,7 +122,7 @@ func startHTTP(ctx context.Context, handler http.Handler, cfg *config.Config) (f
 		log.Print("starting HTTP+HTTPS server in Let’s Encrypt mode")
 
 		certManager := autocert.Manager{
-			Cache:      autocert.DirCache("."),
+			Cache:      autocert.DirCache(cfg.Storage.CertDir),
 			HostPolicy: autocert.HostWhitelist(cfg.Server.Domain),
 			Prompt:     autocert.AcceptTOS,
 		}


### PR DESCRIPTION
Allows specifying a directory (full of html/etc) to serve statically.

```toml
[storage]
static = "./static"
certs  = "./certs"
```

Leaving as a draft as it's merging into #8.