### PR TITLE
Tighten up golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,10 @@ linters:
     - gomnd
     - lll
     - wsl
+    - gosec
 
 issues:
+  exclude-use-default: false
   exclude:
     # Triggered by table tests calling t.Run. See
     # https://github.com/kyoh86/scopelint/issues/4 for more information.

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -1,3 +1,4 @@
+// Package auth facilitates an OAuth login/logout flow.
 package auth
 
 import (
@@ -13,7 +14,7 @@ import (
 
 const (
 	tokenCookieNew     = "token=%s"
-	tokenCookieExpired = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT" // nolint:gosec
+	tokenCookieExpired = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
 )
 
 // OAuth facilitates an Oauth2 login flow via http handlers.

--- a/certifier/loaders.go
+++ b/certifier/loaders.go
@@ -10,22 +10,22 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-type GCS struct {
+type gcs struct {
 	bucket string
 	prefix string
 }
 
-type Live struct {
+type live struct {
 	liveDir string
 }
 
-func (live *Live) Load(path string) ([]byte, error) {
+func (live *live) load(path string) ([]byte, error) {
 	path = filepath.Join(live.liveDir, path)
 
 	return ioutil.ReadFile(path)
 }
 
-func (gcs *GCS) Load(ctx context.Context, path string) ([]byte, error) {
+func (gcs *gcs) load(ctx context.Context, path string) ([]byte, error) {
 	path = filepath.Join(gcs.prefix, path)
 
 	client, err := storage.NewClient(ctx)
@@ -41,12 +41,12 @@ func (gcs *GCS) Load(ctx context.Context, path string) ([]byte, error) {
 		return nil, err
 	}
 
-	defer reader.Close()
+	defer reader.Close() // nolint:errcheck
 
 	return ioutil.ReadAll(reader)
 }
 
-func (gcs *GCS) Save(ctx context.Context, path string, data []byte) error {
+func (gcs *gcs) save(ctx context.Context, path string, data []byte) error {
 	path = filepath.Join(gcs.prefix, path)
 
 	client, err := storage.NewClient(ctx)
@@ -58,7 +58,7 @@ func (gcs *GCS) Save(ctx context.Context, path string, data []byte) error {
 
 	obj := bh.Object(path)
 	w := obj.NewWriter(ctx)
-	defer w.Close()
+	defer w.Close() // nolint:errcheck
 	r := bytes.NewBuffer(data)
 
 	_, err = io.Copy(w, r)

--- a/certifier/main.go
+++ b/certifier/main.go
@@ -61,19 +61,19 @@ func mainCmd() error {
 		filepath.Join(cfg.CertName, "privkey.pem"),
 	}
 
-	gcs := GCS{
+	gcs := gcs{
 		bucket: cfg.GCSBucket,
 		prefix: cfg.GCSPrefix,
 	}
 
-	live := Live{
+	live := live{
 		liveDir: liveDir,
 	}
 
 	// Find existing certificate (if any) and determine if it needs to be renewed.
 	renew := func() bool {
 		certPath := filepath.Join(cfg.CertName, "cert.pem")
-		body, err := gcs.Load(context.Background(), certPath)
+		body, err := gcs.load(context.Background(), certPath)
 		if err != nil {
 			log.Printf("Failed to load certificate from GCS")
 			return true
@@ -103,7 +103,7 @@ func mainCmd() error {
 	// Copy all generated files to GCS
 	for _, file := range files {
 		log.Printf("Loading %q from disk", file)
-		data, err := live.Load(file)
+		data, err := live.load(file)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func mainCmd() error {
 		}
 
 		log.Printf("Saving %q to GCS", file)
-		if err := gcs.Save(context.Background(), file, data); err != nil {
+		if err := gcs.save(context.Background(), file, data); err != nil {
 			return err
 		}
 		log.Printf("Saved %q to GCS", file)

--- a/cmd/infractl/cluster/command.go
+++ b/cmd/infractl/cluster/command.go
@@ -1,3 +1,4 @@
+// Package cluster implements the infractl cluster ... command.
 package cluster
 
 import (

--- a/cmd/infractl/cluster/flavor/command.go
+++ b/cmd/infractl/cluster/flavor/command.go
@@ -1,3 +1,4 @@
+// Package flavor implements the infractl cluster flavor command.
 package flavor
 
 import (

--- a/cmd/infractl/common/flags.go
+++ b/cmd/infractl/common/flags.go
@@ -1,3 +1,5 @@
+// Package common provides some helper functionality for building command line
+// handlers.
 package common
 
 import (
@@ -11,7 +13,7 @@ import (
 const (
 	// tokenEnvVarName is the environment variable name used to pass a service
 	// account token.
-	tokenEnvVarName = "INFRACTL_TOKEN" // nolint:gosec
+	tokenEnvVarName = "INFRACTL_TOKEN"
 
 	// defaultEndpoint is the default infra-server address to connect to.
 	defaultEndpoint = "localhost:8823"

--- a/cmd/infractl/common/grpc.go
+++ b/cmd/infractl/common/grpc.go
@@ -19,7 +19,7 @@ func GetGRPCConnection() (*grpc.ClientConn, context.Context, func(), error) {
 	if insecure() {
 		allDialOpts = append(allDialOpts,
 			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-				InsecureSkipVerify: true, // nolint:gosec
+				InsecureSkipVerify: true,
 			})),
 		)
 	} else {

--- a/cmd/infractl/common/handler.go
+++ b/cmd/infractl/common/handler.go
@@ -9,12 +9,21 @@ import (
 	"google.golang.org/grpc"
 )
 
+// PrettyPrinter represents a type that knows how to render itself in a pretty,
+// human-readable fashion to STDOUT.
 type PrettyPrinter interface {
+	// PrettyPrint renders this type in a pretty, human-readable fashion to
+	// STDOUT.
 	PrettyPrint()
 }
 
+// GRPCHandler represents a function that consumes a gRPC connection, and
+// produces a pretty-printable type.
 type GRPCHandler func(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, args []string) (PrettyPrinter, error)
 
+// WithGRPCHandler performs all of the gRPC connection setup and teardown, as
+// well as rendering the returned type as either JSON or in a human-readable
+// fashion.
 func WithGRPCHandler(handler GRPCHandler) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Obtain a GRPC connection if possible.

--- a/cmd/infractl/version/command.go
+++ b/cmd/infractl/version/command.go
@@ -1,3 +1,4 @@
+// Package version implements the infractl version command.
 package version
 
 import (

--- a/cmd/infractl/whoami/command.go
+++ b/cmd/infractl/whoami/command.go
@@ -1,3 +1,4 @@
+// Package whoami implements the infractl whoami command.
 package whoami
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides configurability for the entire application.
 package config
 
 import (
@@ -7,14 +8,26 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Config represents the top-level configuration for infra-server.
 type Config struct {
-	Auth0           Auth0Config            `toml:"auth0"`
-	Server          ServerConfig           `toml:"server"`
-	Storage         StorageConfig          `toml:"storage"`
+	// Auth0 is the authentication, encryption, and Auth0 configuration.
+	Auth0 Auth0Config `toml:"auth0"`
+
+	// Server is the server and TLS configuration.
+	Server ServerConfig `toml:"server"`
+
+	// StaticDir is the directory to server static assets from.
+	StaticDir string `toml:"static"`
+
+	// ServiceAccounts is a list of service accounts.
 	ServiceAccounts []ServiceAccountConfig `toml:"service-account"`
-	Flavors         []FlavorConfig         `toml:"flavor"`
+
+	// Flavors is a list of automation flavors.
+	Flavors []FlavorConfig `toml:"flavor"`
 }
 
+// Auth0Config represents the configuration used for authentication,
+// encryption, and interacting with Auth0.
 type Auth0Config struct {
 	ClientID     string `toml:"client-id"`
 	ClientSecret string `toml:"client-secret"`
@@ -28,6 +41,8 @@ type Auth0Config struct {
 	PublicKey    string `toml:"public-key"`
 }
 
+// ServerConfig represents the configuration used for running the HTTP & GRPC
+// servers, and providing TLS.
 type ServerConfig struct {
 	GRPC     string `toml:"grpc"`
 	HTTPS    string `toml:"https"`
@@ -37,10 +52,8 @@ type ServerConfig struct {
 	CertDir  string `toml:"certs"`
 }
 
-type StorageConfig struct {
-	StaticDir string `toml:"static"`
-}
-
+// ServiceAccountConfig represents the configuration for a single service
+// account.
 type ServiceAccountConfig struct {
 	// Name is a human readable name for the service account.
 	Name string `toml:"name"`
@@ -53,6 +66,7 @@ type ServiceAccountConfig struct {
 	Token string `toml:"token"`
 }
 
+// FlavorConfig represents the configuration for a single automation flavor.
 type FlavorConfig struct {
 	// ID is the unique, human type-able, ID for the flavor.
 	ID string `toml:"id"`
@@ -73,6 +87,7 @@ type FlavorConfig struct {
 	Image string `toml:"image"`
 }
 
+// Load reads and parses the given configuration file.
 func Load(filename string) (*Config, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,3 +1,5 @@
+// Package buildinfo provides information about the built binary and the
+// environment in which it was built.
 package buildinfo
 
 import (

--- a/service/middleware/enrichers.go
+++ b/service/middleware/enrichers.go
@@ -1,3 +1,5 @@
+// Package middleware provides functionality for instrumenting and enriching
+// grpc connections.
 package middleware
 
 import (

--- a/service/middleware/service.go
+++ b/service/middleware/service.go
@@ -14,8 +14,11 @@ type APIService interface {
 	RegisterServiceHandler(context.Context, *runtime.ServeMux, *grpc.ClientConn) error
 }
 
+// APIServiceFunc represents a function that is capable of making a APIService.
 type APIServiceFunc func() (APIService, error)
 
+// Services process the given APIServiceFunc list, and returns the resulting
+// APIService list. If any errors occur, that error is returned immediately.
 func Services(serviceFuncs ...APIServiceFunc) ([]APIService, error) {
 	services := make([]APIService, len(serviceFuncs))
 	for index, serviceFunc := range serviceFuncs {

--- a/service/package.go
+++ b/service/package.go
@@ -1,0 +1,2 @@
+// Package service provides implementations for all of the gRPC services.
+package service


### PR DESCRIPTION
Non-functional change, just raise the requirement bar for `golangci-lint` moving forward.

- Require comments on exported entities.