### PR TITLE
Cluster lifespan API and tooling

### DIFF
--- a/cmd/infractl/cluster/command.go
+++ b/cmd/infractl/cluster/command.go
@@ -4,6 +4,7 @@ package cluster
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/infra/cmd/infractl/cluster/info"
+	"github.com/stackrox/infra/cmd/infractl/cluster/lifespan"
 	"github.com/stackrox/infra/cmd/infractl/cluster/list"
 )
 
@@ -22,6 +23,9 @@ func Command() *cobra.Command {
 
 		// $ infractl cluster list
 		list.Command(),
+
+		// $ infractl cluster lifespan
+		lifespan.Command(),
 	)
 
 	return cmd

--- a/cmd/infractl/cluster/lifespan/command.go
+++ b/cmd/infractl/cluster/lifespan/command.go
@@ -1,0 +1,54 @@
+// Package lifespan implements the infractl cluster lifespan command.
+package lifespan
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/infra/cmd/infractl/common"
+	v1 "github.com/stackrox/infra/generated/api/v1"
+	"google.golang.org/grpc"
+)
+
+const examples = `# Set the lifespan of cluster example-s3maj to 30 minutes.
+infractl cluster lifespan example-s3maj 30m
+
+# Expire cluster example-s3maj.
+infractl cluster lifespan example-s3maj 0
+`
+
+// Command defines the handler for infractl cluster lifespan.
+func Command() *cobra.Command {
+	// $ infractl cluster lifespan
+	return &cobra.Command{
+		Use:     "lifespan <cluster id> <duration>",
+		Short:   "update cluster lifespan",
+		Long:    "lifespan updates the cluster lifespan",
+		Example: examples,
+		RunE:    common.WithGRPCHandler(lifespan),
+	}
+}
+
+func lifespan(ctx context.Context, conn *grpc.ClientConn, _ *cobra.Command, args []string) (common.PrettyPrinter, error) {
+	if len(args) != 2 {
+		return nil, errors.New("invalid arguments")
+	}
+
+	lifespan, err := time.ParseDuration(args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := v1.NewClusterServiceClient(conn).Lifespan(ctx, &v1.LifespanRequest{
+		Id:       args[0],
+		Lifespan: ptypes.DurationProto(lifespan),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return dur(*resp), nil
+}

--- a/cmd/infractl/cluster/lifespan/fancy.go
+++ b/cmd/infractl/cluster/lifespan/fancy.go
@@ -1,0 +1,17 @@
+package lifespan
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/ptypes"
+	durpb "github.com/golang/protobuf/ptypes/duration"
+)
+
+type dur durpb.Duration
+
+func (r dur) PrettyPrint() {
+	delta := durpb.Duration(r)
+	lifespan, _ := ptypes.Duration(&delta)
+
+	fmt.Println(lifespan)
+}

--- a/proto/api/v1/service.proto
+++ b/proto/api/v1/service.proto
@@ -202,6 +202,14 @@ message ClusterListResponse {
     repeated Cluster Clusters = 1;
 }
 
+message LifespanRequest {
+    // ID is the unique ID for the cluster.
+    string id = 1;
+
+    // Lifespan is the new lifespan.
+    google.protobuf.Duration Lifespan = 2;
+}
+
 // FlavorService provides flavor based functionality.
 service ClusterService {
     // Info provides information about a specific cluster.
@@ -215,6 +223,14 @@ service ClusterService {
     rpc List (google.protobuf.Empty) returns (ClusterListResponse) {
         option (google.api.http) = {
             get: "/v1/cluster"
+        };
+    }
+
+    // Lifespan updates the lifespan for a specific cluster.
+    rpc Lifespan (LifespanRequest) returns (google.protobuf.Duration) {
+        option (google.api.http) = {
+            post: "/v1/cluster/{id}/lifespan"
+            body: "*"
         };
     }
 }

--- a/service/cluster/annotations.go
+++ b/service/cluster/annotations.go
@@ -44,5 +44,9 @@ func GetLifespan(a Annotated) *duration.Duration {
 		lifespan = 3 * time.Hour
 	}
 
+	if lifespan <= 0 {
+		// Ensure that the lifespan isn't negative.
+		lifespan = 0
+	}
 	return ptypes.DurationProto(lifespan)
 }


### PR DESCRIPTION
API and CLI for setting a given cluster's lifespan:

```
$ infractl -k cluster lifespan gke-default-sd7jp 3h30m0s
3h30m0s
```

Mechanically, this is implemented by reading/patching the `infra.stackrox.com/lifespan` annotation on the `workflow` object:

```yaml
kubectl get workflow gke-default-sd7jp -o yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  annotations:
    infra.stackrox.com/flavor: gke-default
    infra.stackrox.com/lifespan: 3h30m0s
    infra.stackrox.com/owner: josh@stackrox.com
```