### PR TITLE
HTTP route authorization wrapper

### DIFF
--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -149,7 +149,7 @@ func (a OAuth) Authorized(handler http.Handler) http.Handler {
 			return
 		}
 
-		// USer is authorized, invoke original handler.
+		// User is authorized, invoke original handler.
 		handler.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
@al13n this is what I was referring to in #36. Adds a function that wraps an `http.Handler` in an authorization check. Can be used like:

```go
mux.Handle("/downloads", s.oauth.Authorized(http.FileServer(http.Dir(...))))
```