### PR TITLE
Simple UI for generating a service account token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ infra.toml
 certs/
 sessions/
 image/infra-server
+image/static
 chart-rendered
 chart/infra-server/configs
 chart/infra-server/secrets

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ cli-local: proto-generated-srcs
 .PHONY: image
 image: server cli
 	@cp -f bin/infra-server-linux-amd64 image/infra-server
-	@cp -r static image/static
-	@cp bin/infractl-darwin-amd64 image/
-	@cp bin/infractl-linux-amd64 image/
+	@cp -r static image/
+	@mkdir -p image/static/downloads
+	@cp bin/infractl-darwin-amd64 image/static/downloads
+	@cp bin/infractl-linux-amd64 image/static/downloads
 	docker build -t us.gcr.io/stackrox-infra/infra-server:$(TAG) image
 
 ##############

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -107,7 +107,7 @@ func (a OAuth) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	// Persist the user token as a cookie in the user's browser and redirect to
 	// a logged in page
 	w.Header().Set("set-cookie", fmt.Sprintf(tokenCookieNew, userToken))
-	http.Redirect(w, r, "/v1/whoami", http.StatusTemporaryRedirect)
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 // logoutHandler handles the logout part of an Oauth2 flow.
@@ -139,13 +139,13 @@ func (a OAuth) Authorized(handler http.Handler) http.Handler {
 		// Extract the "token" cookie from the request.
 		cookie, err := r.Cookie("token")
 		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Validate the token JWT.
 		if _, err := a.jwtUser.Validate(cookie.Value); err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 			return
 		}
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -2,10 +2,8 @@ FROM alpine:3.10
 
 RUN apk add --no-cache ca-certificates=20190108-r0
 
-COPY static /etc/infra/
-
 COPY infra-server /infra-server
 
-COPY infractl-darwin-amd64 infractl-linux-amd64 /etc/infra/static/downloads/
+COPY static /etc/infra/static
 
 ENTRYPOINT ["/infra-server"]

--- a/static/index.html
+++ b/static/index.html
@@ -1,13 +1,24 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title>Infra server</title>
+    <meta charset="UTF-8">
+    <title>Infra | Home</title>
     <link rel="shortcut icon" href="favicon.ico">
 </head>
 <body>
-    <a href="/login">/login</a>
-    <a href="/logout">/logout</a>
-    <a href="/v1/version">/v1/version</a>
-    <a href="/v1/whoami">/v1/whoami</a>
+    <a href="/login">Login</a>
+    <br>
+    <a href="/logout">Logout</a>
+    <br>
+    <a href="/token">Generate a service account token</a>
+    <br>
+    <a href="/v1/version">Version information</a>
+    <br>
+    <a href="/v1/whoami">User Information</a>
+    <br>
+    <a href="/downloads/infractl-darwin-amd64">Download infractl for Mac</a>
+    <br>
+    <a href="/downloads/infractl-linux-amd64">Download infractl for Linux</a>
 </body>
 </html>
 

--- a/static/token/index.html
+++ b/static/token/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Infra | Generate Token</title>
+    <link rel="shortcut icon" href="favicon.ico">
+    <style type="text/css">
+        #generate {
+            background-color: #0a0;
+            border: none;
+            color: white;
+            padding: 10px;
+            font-size: 12pt;
+        }
+        #output {
+            background-color: #223;
+            color: white;
+            display: none;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+    <button id="generate">Generate Token</button>
+    <pre id="output"></pre>
+</body>
+<script src="/token/index.js" type="text/javascript"></script>
+</html>

--- a/static/token/index.js
+++ b/static/token/index.js
@@ -1,0 +1,48 @@
+'use strict';
+
+function handle(xhttp, success, failure) {
+    xhttp.onreadystatechange = function() {
+        if (this.readyState === 4){
+            const obj = JSON.parse(xhttp.responseText);
+            if (this.status === 200) {
+                if (typeof success === 'function') {
+                    return success(obj);
+                }
+                console.error("tried to call success function, but it was null");
+            } else {
+                if (typeof failure === 'function') {
+                    return failure(obj);
+                }
+                console.error("tried to call failure function, but it was null");
+            }
+        }
+    };
+}
+
+function generateToken(success, failure){
+    var xhttp = new XMLHttpRequest();
+    handle(xhttp, success, failure);
+    xhttp.open("POST", "/v1/token", true);
+    xhttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+    xhttp.send();
+}
+
+function main() {
+    const generate = document.getElementById("generate");
+    const output = document.getElementById("output");
+
+    generate.onclick = function(){
+        generateToken(function (resp) {
+            console.log(resp);
+            var text = `# Run the following in a terminal to configure infractl for use:\nexport INFRA_TOKEN='${resp.Token}'`;
+            output.innerText = text;
+            output.style.display = "inline-block"
+        }, function (resp) {
+            console.error(resp);
+        })
+    };
+}
+
+(function(){
+    window.onload = main;
+})();


### PR DESCRIPTION
// HTML content in this PR is intended as a stop-gap (until proper UI is built)

Adds a single page that allows the logged-in user to generate a service account token in a self-service manner. This way, users adopting the service can onboard themselves (opposed to _needing_ to ping me 😜)

![image](https://user-images.githubusercontent.com/307183/76270412-6cb66100-6232-11ea-8cd0-614230e14d53.png)
