### PR TITLE
Add react-router@6

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -24,12 +24,16 @@
   "dependencies": {
     "@tippy.js/react": "^3.1.1",
     "axios": "^0.19.2",
+    "history": "^5.0.0-beta.4",
     "initials": "^3.0.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",
+    "react-router": "^6.0.0-alpha.3",
+    "react-router-dom": "^6.0.0-alpha.3",
     "react-spinners": "^0.8.1"
   },
   "devDependencies": {
@@ -41,6 +45,8 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "@types/react-router": "^5.1.7",
+    "@types/react-router-dom": "^5.1.5",
     "eslint-config-airbnb-typescript": "^7.2.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-comments": "^3.1.2",

--- a/ui/src/containers/App.tsx
+++ b/ui/src/containers/App.tsx
@@ -1,23 +1,25 @@
 import React, { ReactElement } from 'react';
-import { Gift } from 'react-feather';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import UserAuthProvider from 'containers/UserAuthProvider';
 import { ThemeProvider } from 'containers/ThemeProvider';
 import AppHeader from 'containers/AppHeader';
+import HomePage from 'containers/HomePage';
 
 function App(): ReactElement {
   return (
-    <ThemeProvider>
-      <UserAuthProvider>
-        <div className="flex flex-col h-full bg-base-0">
-          <AppHeader />
-          <div className="flex flex-col flex-1 items-center justify-center">
-            <Gift size={128} />
-            <span className="text-6xl pt-10">Coming Soon</span>
+    <Router>
+      <ThemeProvider>
+        <UserAuthProvider>
+          <div className="flex flex-col h-full bg-base-0">
+            <AppHeader />
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+            </Routes>
           </div>
-        </div>
-      </UserAuthProvider>
-    </ThemeProvider>
+        </UserAuthProvider>
+      </ThemeProvider>
+    </Router>
   );
 }
 

--- a/ui/src/containers/HomePage.tsx
+++ b/ui/src/containers/HomePage.tsx
@@ -1,0 +1,11 @@
+import React, { ReactElement } from 'react';
+import { Gift } from 'react-feather';
+
+export default function HomePage(): ReactElement {
+  return (
+    <div className="flex flex-col flex-1 items-center justify-center">
+      <Gift size={128} />
+      <span className="text-6xl pt-10">Coming Soon</span>
+    </div>
+  );
+}

--- a/ui/src/types/react-router-dom.d.ts
+++ b/ui/src/types/react-router-dom.d.ts
@@ -1,0 +1,180 @@
+/* eslint no-var: 0, vars-on-top: 0, no-redeclare: 0, import/export: 0, @typescript-eslint/no-explicit-any: 0 */
+
+/**
+ * These definitions are copied from the build artifacts of react-router branch
+ * https://github.com/ReactTraining/react-router/tree/ts.
+ *
+ * TODO:
+ *  - remove this file as soon as react-router@6 is released
+ *  - also `yarn remove @types/react-router-dom
+ */
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { State, To } from 'history';
+import {
+  MemoryRouter,
+  Navigate,
+  Outlet,
+  Route,
+  Router,
+  Routes,
+  useBlocker,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useLocationPending,
+  useMatch,
+  useNavigate,
+  useOutlet,
+  useParams,
+  useResolvedLocation,
+  useRoutes,
+  createRoutesFromArray,
+  createRoutesFromChildren,
+  generatePath,
+  matchRoutes,
+  resolveLocation,
+} from 'react-router';
+
+declare module 'react-router-dom' {
+  export {
+    MemoryRouter,
+    Navigate,
+    Outlet,
+    Route,
+    Router,
+    Routes,
+    useBlocker,
+    useHref,
+    useInRouterContext,
+    useLocation,
+    useLocationPending,
+    useMatch,
+    useNavigate,
+    useOutlet,
+    useParams,
+    useResolvedLocation,
+    useRoutes,
+    createRoutesFromArray,
+    createRoutesFromChildren,
+    generatePath,
+    matchRoutes,
+    resolveLocation,
+  };
+  /**
+   * A <Router> for use in web browsers. Provides the cleanest URLs.
+   */
+  export function BrowserRouter({ children, timeout, window }: BrowserRouterProps): JSX.Element;
+  export namespace BrowserRouter {
+    var displayName: string;
+    var propTypes: {
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+      timeout: PropTypes.Requireable<number>;
+      window: PropTypes.Requireable<object>;
+    };
+  }
+  export interface BrowserRouterProps {
+    children?: React.ReactNode;
+    timeout?: number;
+    window?: Window;
+  }
+  /**
+   * A <Router> for use in web browsers. Stores the location in the hash
+   * portion of the URL so it is not sent to the server.
+   */
+  export function HashRouter({ children, timeout, window }: HashRouterProps): JSX.Element;
+  export namespace HashRouter {
+    var displayName: string;
+    var propTypes: {
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+      timeout: PropTypes.Requireable<number>;
+      window: PropTypes.Requireable<object>;
+    };
+  }
+  export interface HashRouterProps {
+    children?: React.ReactNode;
+    timeout?: number;
+    window?: Window;
+  }
+  /**
+   * The public API for rendering a history-aware <a>.
+   */
+  export const Link: React.ForwardRefExoticComponent<
+    LinkProps & React.RefAttributes<HTMLAnchorElement>
+  >;
+  export interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+    replace?: boolean;
+    state?: State;
+    to: To;
+  }
+  /**
+   * A <Link> wrapper that knows if it's "active" or not.
+   */
+  export const NavLink: React.ForwardRefExoticComponent<
+    NavLinkProps & React.RefAttributes<HTMLAnchorElement>
+  >;
+  export interface NavLinkProps extends LinkProps {
+    activeClassName?: string;
+    activeStyle?: object;
+  }
+  /**
+   * A declarative interface for showing a window.confirm dialog with the given
+   * message when the user tries to navigate away from the current page.
+   *
+   * This also serves as a reference implementation for anyone who wants to
+   * create their own custom prompt component.
+   */
+  export function Prompt({ message, when }: PromptProps): null;
+  export namespace Prompt {
+    var displayName: string;
+    var propTypes: {
+      message: PropTypes.Requireable<string>;
+      when: PropTypes.Requireable<boolean>;
+    };
+  }
+  export interface PromptProps {
+    message: string;
+    when?: boolean;
+  }
+  /**
+   * Prevents navigation away from the current page using a window.confirm prompt
+   * with the given message.
+   */
+  export function usePrompt(message: string, when?: boolean): void;
+  /**
+   * A convenient wrapper for reading and writing search parameters via the
+   * URLSearchParams interface.
+   */
+  export function useSearchParams(
+    defaultInit: URLSearchParamsInit
+  ): (URLSearchParams | ((nextInit: any, navigateOpts: any) => void))[];
+  /**
+   * Creates a URLSearchParams object using the given initializer.
+   *
+   * This is identical to `new URLSearchParams(init)` except it also
+   * supports arrays as values in the object form of the initializer
+   * instead of just strings. This is convenient when you need multiple
+   * values for a given key, but don't want to use an array initializer.
+   *
+   * For example, instead of:
+   *
+   *   let searchParams = new URLSearchParams([
+   *     ['sort', 'name'],
+   *     ['sort', 'price']
+   *   ]);
+   *
+   * you can do:
+   *
+   *   let searchParams = createSearchParams({
+   *     sort: ['name', 'price']
+   *   });
+   */
+  export function createSearchParams(init?: URLSearchParamsInit): URLSearchParams;
+  export type ParamKeyValuePair = [string, string];
+  export type URLSearchParamsInit =
+    | string
+    | ParamKeyValuePair[]
+    | Record<string, string | string[]>
+    | URLSearchParams;
+}

--- a/ui/src/types/react-router.d.ts
+++ b/ui/src/types/react-router.d.ts
@@ -1,0 +1,290 @@
+/* eslint no-var: 0, vars-on-top: 0, no-redeclare: 0, import/export: 0, @typescript-eslint/no-explicit-any: 0 */
+
+/**
+ * These definitions are copied from the build artifacts of react-router branch
+ * https://github.com/ReactTraining/react-router/tree/ts.
+ *
+ * TODO:
+ *  - remove this file as soon as react-router@6 is released
+ *  - also `yarn remove @types/react-router
+ */
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Path, State, PathPieces, Location, Blocker, To, History, InitialEntry } from 'history';
+
+declare module 'react-router' {
+  /**
+   * A <Router> that stores all entries in memory.
+   */
+  export function MemoryRouter({
+    children,
+    initialEntries,
+    initialIndex,
+    timeout,
+  }: MemoryRouterProps): React.ReactElement;
+  export namespace MemoryRouter {
+    var displayName: string;
+    var propTypes: {
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+      timeout: PropTypes.Requireable<number>;
+      initialEntries: PropTypes.Requireable<
+        (
+          | string
+          | PropTypes.InferProps<{
+              pathname: PropTypes.Requireable<string>;
+              search: PropTypes.Requireable<string>;
+              hash: PropTypes.Requireable<string>;
+              state: PropTypes.Requireable<object>;
+              key: PropTypes.Requireable<string>;
+            }>
+          | null
+          | undefined
+        )[]
+      >;
+      initialIndex: PropTypes.Requireable<number>;
+    };
+  }
+  export interface MemoryRouterProps {
+    children?: React.ReactNode;
+    initialEntries?: InitialEntry[];
+    initialIndex?: number;
+    timeout?: number;
+  }
+  /**
+   * Navigate programmatically using a component.
+   */
+  export function Navigate({ to, replace, state }: NavigateProps): null;
+  export namespace Navigate {
+    var displayName: string;
+    var propTypes: {
+      to: PropTypes.Validator<
+        | string
+        | PropTypes.InferProps<{
+            pathname: PropTypes.Requireable<string>;
+            search: PropTypes.Requireable<string>;
+            hash: PropTypes.Requireable<string>;
+          }>
+      >;
+      replace: PropTypes.Requireable<boolean>;
+      state: PropTypes.Requireable<object>;
+    };
+  }
+  export interface NavigateProps {
+    to: To;
+    replace?: boolean;
+    state?: State;
+  }
+  /**
+   * Renders the child route's element, if there is one.
+   */
+  export function Outlet(): React.ReactElement | null;
+  export namespace Outlet {
+    var displayName: string;
+    var propTypes: {};
+  }
+  /**
+   * Used in a route config to render an element.
+   */
+  export function Route({ element }: RouteProps): React.ReactElement | null;
+  export namespace Route {
+    var displayName: string;
+    var propTypes: {
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+      element: PropTypes.Requireable<PropTypes.ReactElementLike>;
+      path: PropTypes.Requireable<string>;
+    };
+  }
+  export interface RouteProps {
+    children?: React.ReactNode;
+    element?: React.ReactElement | null;
+    path?: string;
+  }
+  /**
+   * The root context provider. There should be only one of these in a given app.
+   */
+  export function Router({
+    children,
+    history,
+    static: staticProp,
+    timeout,
+  }: RouterProps): React.ReactElement;
+  export namespace Router {
+    var displayName: string;
+    var propTypes: {
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+      history: PropTypes.Requireable<
+        PropTypes.InferProps<{
+          action: PropTypes.Requireable<string>;
+          location: PropTypes.Requireable<object>;
+          push: PropTypes.Requireable<(...args: any[]) => any>;
+          replace: PropTypes.Requireable<(...args: any[]) => any>;
+          go: PropTypes.Requireable<(...args: any[]) => any>;
+          listen: PropTypes.Requireable<(...args: any[]) => any>;
+          block: PropTypes.Requireable<(...args: any[]) => any>;
+        }>
+      >;
+      timeout: PropTypes.Requireable<number>;
+    };
+  }
+  export interface RouterProps {
+    children?: React.ReactNode;
+    history: History;
+    static?: boolean;
+    timeout?: number;
+  }
+  /**
+   * A wrapper for useRoutes that treats its children as route and/or redirect
+   * objects.
+   */
+  export function Routes({
+    basename,
+    caseSensitive,
+    children,
+  }: RoutesProps): React.ReactElement | null;
+  export namespace Routes {
+    var displayName: string;
+    var propTypes: {
+      basename: PropTypes.Requireable<string>;
+      caseSensitive: PropTypes.Requireable<boolean>;
+      children: PropTypes.Requireable<PropTypes.ReactNodeLike>;
+    };
+  }
+  export interface RoutesProps {
+    basename?: string;
+    caseSensitive?: boolean;
+    children?: React.ReactNode;
+  }
+  /**
+   * Blocks all navigation attempts. This is useful for preventing the page from
+   * changing until some condition is met, like saving form data.
+   */
+  export function useBlocker(blocker: Blocker, when?: boolean): void;
+  /**
+   * Returns the full href for the given "to" value. This is useful for building
+   * custom links that are also accessible and preserve right-click behavior.
+   */
+  export function useHref(to: To): string;
+  /**
+   * Returns true if this component is a descendant of a <Router>.
+   */
+  export function useInRouterContext(): boolean;
+  /**
+   * Returns the current location object, which represents the current URL in web
+   * browsers.
+   *
+   * NOTE: If you're using this it may mean you're doing some of your own
+   * "routing" in your app, and we'd like to know what your use case is. We may be
+   * able to provide something higher-level to better suit your needs.
+   */
+  export function useLocation(): Location;
+  /**
+   * Returns true if the router is pending a location update.
+   */
+  export function useLocationPending(): boolean;
+  /**
+   * Returns true if the URL for the given "to" value matches the current URL.
+   * This is useful for components that need to know "active" state, e.g.
+   * <NavLink>.
+   */
+  export function useMatch(to: To): boolean;
+  /**
+   * The interface for the navigate() function returned from useNavigate().
+   */
+  export interface NavigateFunction {
+    (
+      to: To | number,
+      options?: {
+        replace?: boolean;
+        state?: State | null;
+      }
+    ): void;
+  }
+  /**
+   * Returns an imperative method for changing the location. Used by <Link>s, but
+   * may also be used by other elements to change the location.
+   */
+  export function useNavigate(): NavigateFunction;
+  /**
+   * Returns the outlet element at this level of the route hierarchy. Used to
+   * render child routes.
+   */
+  export function useOutlet(): React.ReactElement | null;
+  /**
+   * Returns a hash of the dynamic params that were matched in the route path.
+   * This is useful for using ids embedded in the URL to fetch data, but we
+   * eventually want to provide something at a higher level for this.
+   */
+  export function useParams(): Params;
+  /**
+   * Returns a fully-resolved location object relative to the current location.
+   */
+  export function useResolvedLocation(to: To): ResolvedLocation;
+  /**
+   * Returns the element of the route that matched the current location, prepared
+   * with the correct context to render the remainder of the route tree. Route
+   * elements in the tree must render an <Outlet> to render their child route's
+   * element.
+   */
+  export function useRoutes(
+    routes: PartialRouteObject[],
+    basename?: string,
+    caseSensitive?: boolean
+  ): React.ReactElement | null;
+  /**
+   * Utility function that creates a routes config object from an array of
+   * PartialRouteObject objects.
+   */
+  export function createRoutesFromArray(array: PartialRouteObject[]): RouteObject[];
+  /**
+   * Utility function that creates a routes config object from a React "children"
+   * object, which is usually either a <Route> element or an array of them.
+   */
+  export function createRoutesFromChildren(children: React.ReactNode): RouteObject[];
+  /**
+   * A "partial route" object is usually supplied by the user and may omit certain
+   * properties of a real route object such as `path` and `element`, which have
+   * reasonable defaults.
+   */
+  export interface PartialRouteObject {
+    path?: string;
+    element?: React.ReactNode;
+    children?: PartialRouteObject[];
+  }
+  /**
+   * A route object represents a logical route, with (optionally) its child routes
+   * organized in a tree-like structure.
+   */
+  export interface RouteObject {
+    path: string;
+    element: React.ReactNode;
+    children?: RouteObject[];
+  }
+  /**
+   * Creates a path with params interpolated.
+   */
+  export function generatePath(pathname: string, params?: Params): string;
+  /**
+   * The parameters that were parsed from the URL path.
+   */
+  export type Params = Record<string, string>;
+  /**
+   * Matches the given routes to a location and returns the match data.
+   */
+  export function matchRoutes(
+    routes: PartialRouteObject[],
+    location: Path | PathPieces,
+    basename?: string,
+    caseSensitive?: boolean
+  ): MatchObject[] | null;
+  export interface MatchObject {
+    params: Params;
+    pathname: string;
+    route: RouteObject;
+  }
+  /**
+   * Returns a fully resolved location object relative to the given pathname.
+   */
+  export function resolveLocation(to: To, fromPathname?: string): ResolvedLocation;
+  export type ResolvedLocation = Omit<Location, 'state' | 'key'>;
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -912,6 +912,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -1528,6 +1535,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
+  integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
+
 "@types/http-proxy@^1.17.3":
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
@@ -1602,6 +1614,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.6.tgz#9e7f83d90566521cc2083be2277c6712dcaf754c"
   integrity sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.5.tgz#7c334a2ea785dbad2b2dcdd83d2cf3d9973da090"
+  integrity sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*", "@types/react-router@^5.1.7":
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.7.tgz#e9d12ed7dcfc79187e4d36667745b69a5aa11556"
+  integrity sha512-2ouP76VQafKjtuc0ShpwUebhHwJo0G6rhahW9Pb8au3tQTjYXd2jta4wv6U2tGLR/I42yuG00+UXjNYY0dTzbg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.0":
@@ -5302,6 +5331,13 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+history@5.0.0-beta.4, history@^5.0.0-beta.4:
+  version "5.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0-beta.4.tgz#7fd3bb1f6c75d00d9b5112a816766bfc72d1a3cd"
+  integrity sha512-LMUnKPB5UlEzDF1BO0VxtDsrguGPO7SuQEmB/5OjL1305afR1O8FvX29rbJep4g2SLmKK3YdDA7+8ZDs8P8n8g==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -9122,6 +9158,22 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-router-dom@^6.0.0-alpha.3:
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.0.0-alpha.3.tgz#295aa7691de913b81f481b7cb14418e3b2f08edf"
+  integrity sha512-3Fu9Az+ofgv58WxtaPokADdNXJmxE6td5na2HFIN0cgRBYo2TPJ83KlIt4XCNvq1Y473pr8hOkD621CmauztEw==
+  dependencies:
+    history "5.0.0-beta.4"
+    prop-types "^15.7.2"
+
+react-router@^6.0.0-alpha.3:
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.0.0-alpha.3.tgz#c031a5262801315571f8b609620ae9c1b083dee3"
+  integrity sha512-Evp8ua5c7rFDIuF0KK/tkzbh7aPIWWyjWKr3yOLNine1liiphHZidDL/5jLTBjE9HN0/vdCZPuV2VWjZ82TShA==
+  dependencies:
+    history "5.0.0-beta.4"
+    prop-types "^15.7.2"
 
 react-scripts@3.4.1:
   version "3.4.1"


### PR DESCRIPTION
Depends on #49.

Adds `react-router@6` and the corresponding plumbing in the app. One caveat: ReactTraining/react-router#7292 isn't merged yet, therefore I had to provide types myself, which I did by checking out their branch, building it, then taking type definitions from there and copying over to `src/types` here... for some reason it still was complaining, but once I added `@types/react-router` and `@types/react-router-dom` to dev deps, everything started to work and properly picking up new types. Good enough for now :)