### PR TITLE
Add "Launch Cluster" section to the Home page

### DIFF
--- a/ui/src/components/FullPageError.tsx
+++ b/ui/src/components/FullPageError.tsx
@@ -1,14 +1,18 @@
 import React, { ReactElement } from 'react';
-import { AlertCircle } from 'react-feather';
+import { AlertCircle, Icon } from 'react-feather';
 
 type Props = {
   message: string;
+  IconComponent?: Icon;
 };
 
-export default function FullPageError({ message }: Props): ReactElement {
+export default function FullPageError({
+  message,
+  IconComponent = AlertCircle,
+}: Props): ReactElement {
   return (
     <div className="flex flex-row w-full h-full items-center justify-center bg-base-0">
-      <AlertCircle size={64} />
+      <IconComponent size={64} />
       <span className="pl-2 text-4xl">{message}</span>
     </div>
   );

--- a/ui/src/components/LinkCard.tsx
+++ b/ui/src/components/LinkCard.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+type Props = {
+  to: string;
+  header: string;
+  children: ReactNode;
+  footer?: string;
+  className?: string;
+};
+
+export default function LinkCard({
+  to,
+  header,
+  children,
+  footer,
+  className = '',
+}: Props): ReactElement {
+  return (
+    <Link
+      className={`flex flex-col p-2 border-2 border-base-400 shadow rounded font-600 bg-base-100 hover:bg-base-200 text-base-600 hover:text-base-700 ${className}`}
+      to={to}
+    >
+      <h2 className="pb-1 text-2xl border-b-2 border-base-500 mb-4">{header}</h2>
+      {children}
+      {footer && <span className="mt-auto capitalize">{footer}</span>}
+    </Link>
+  );
+}

--- a/ui/src/components/PageSection.tsx
+++ b/ui/src/components/PageSection.tsx
@@ -6,9 +6,9 @@ type Props = {
   children: ReactNode;
 };
 
-export default function PageSection({ header, className, children }: Props): ReactElement {
+export default function PageSection({ header, className = '', children }: Props): ReactElement {
   return (
-    <div className={`${className || ''}`}>
+    <div className={className}>
       <h1 className="pb-2 m-4 border-b-2 text-base-600 font-700 text-4xl">{header}</h1>
       <div className="ml-2 mr-2">{children}</div>
     </div>

--- a/ui/src/containers/App.tsx
+++ b/ui/src/containers/App.tsx
@@ -1,17 +1,23 @@
 import React, { ReactElement } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { Tool } from 'react-feather';
 
 import UserAuthProvider from 'containers/UserAuthProvider';
 import { ThemeProvider } from 'containers/ThemeProvider';
 import AppHeader from 'containers/AppHeader';
 import HomePage from 'containers/HomePage';
 import DownloadsPage from 'containers/DownloadsPage';
+import FullPageError from 'components/FullPageError';
 
 function AppRoutes(): ReactElement {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/downloads" element={<DownloadsPage />} />
+      <Route
+        path="*"
+        element={<FullPageError message="WIP. Pardon our dust." IconComponent={Tool} />}
+      />
     </Routes>
   );
 }

--- a/ui/src/containers/HomePage/HomePage.tsx
+++ b/ui/src/containers/HomePage/HomePage.tsx
@@ -1,11 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Gift } from 'react-feather';
+
+import LaunchPageSection from './LaunchPageSection';
 
 export default function HomePage(): ReactElement {
-  return (
-    <div className="flex flex-col flex-1 items-center justify-center">
-      <Gift size={128} />
-      <span className="text-6xl pt-10">Coming Soon</span>
-    </div>
-  );
+  return <LaunchPageSection />;
 }

--- a/ui/src/containers/HomePage/LaunchPageSection.tsx
+++ b/ui/src/containers/HomePage/LaunchPageSection.tsx
@@ -1,0 +1,49 @@
+import React, { ReactElement } from 'react';
+import { AxiosPromise } from 'axios';
+
+import { V1FlavorListResponse, FlavorServiceApi } from 'generated/client';
+import useApiQuery from 'client/useApiQuery';
+import configuration from 'client/configuration';
+import PageSection from 'components/PageSection';
+import LinkCard from 'components/LinkCard';
+import FullPageSpinner from 'components/FullPageSpinner';
+import FullPageError from 'components/FullPageError';
+
+const flavorService = new FlavorServiceApi(configuration);
+
+const fetchFlavors = (): AxiosPromise<V1FlavorListResponse> => flavorService.list();
+
+function FlavorCards(): ReactElement {
+  const { loading, error, data } = useApiQuery(fetchFlavors);
+
+  if (loading) {
+    return <FullPageSpinner />;
+  }
+
+  if (error || !data?.Flavors) {
+    return <FullPageError message={error?.message || 'Unexpected server response'} />;
+  }
+
+  const cards = data.Flavors.map((flavor) => (
+    <LinkCard
+      key={flavor.ID}
+      to={`launch/${flavor.ID}`}
+      header={flavor.Name || 'Unnamed'}
+      footer={flavor.Availability}
+      className="s-1"
+    >
+      <p className="text-lg">{flavor.Description}</p>
+    </LinkCard>
+  ));
+  return <>{cards}</>;
+}
+
+export default function LaunchPageSection(): ReactElement {
+  return (
+    <PageSection header="Launch Cluster">
+      <div className="grid grid-gap-4 grid-auto-fit grid-dense">
+        <FlavorCards />
+      </div>
+    </PageSection>
+  );
+}


### PR DESCRIPTION
Adds grid of cards representing flavors of clusters user can launch. For the sake of small PRs right now they lead to an error page "WIP. Pardon our dust". That would be a half of the home page according to the [wireframes](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/1140326506/Infra+Web+UI+Wireframes).

![Screen Shot 2020-05-04 at 1 43 35 PM](https://user-images.githubusercontent.com/477269/81012448-6a294f80-8e0e-11ea-9fd5-939c1754290d.png)
