### PR TITLE
Finer Google Calendar integration configuration

### DIFF
--- a/cmd/infra-server/main.go
+++ b/cmd/infra-server/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/infra/auth"
@@ -71,7 +70,7 @@ func mainCmd() error {
 		return errors.Wrapf(err, "failed to load GCS signing credentials")
 	}
 
-	eventSource, err := calendar.NewGoogleCalendar(cfg.GoogleCalendarID, 2*time.Hour)
+	eventSource, err := calendar.NewGoogleCalendar(cfg.Calendar)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create Google Calendar event source")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,11 +16,19 @@ type Config struct {
 	// Server administrator password.
 	Password string `json:"password"`
 
-	// Google Calendar ID for scheduling demos.
-	GoogleCalendarID string `json:"calendar"`
+	// Google Calendar integration configuration.
+	Calendar CalendarConfig `json:"calendar"`
 
 	// Slack notification configuration.
 	Slack SlackConfig `json:"slack"`
+}
+
+// CalendarConfig represents the configuration for integrating with Google
+// Calendar.
+type CalendarConfig struct {
+	ID       string       `json:"id"`
+	Disabled bool         `json:"disabled"`
+	Window   JSONDuration `json:"window"`
 }
 
 // Auth0Config represents the configuration for integrating with Auth0.

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"encoding/json"
+	"time"
+)
+
+var _ json.Marshaler = (*JSONDuration)(nil)
+var _ json.Unmarshaler = (*JSONDuration)(nil)
+
+// JSONDuration represents a time.Duration that is able to be (JSON) marshaled
+// into or unmarshaled from the more human-friendly duration format.
+type JSONDuration time.Duration
+
+// Duration returns the internal time.Duration value.
+func (d JSONDuration) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+// String returns a string representing the duration in the form "72h3m0.5s".
+func (d JSONDuration) String() string {
+	return d.Duration().String()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (d JSONDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *JSONDuration) UnmarshalJSON(b []byte) error {
+	var i int64
+	if err := json.Unmarshal(b, &i); err == nil {
+		*d = JSONDuration(i)
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	duration, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	*d = JSONDuration(duration)
+	return nil
+}

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		yaml     string
+		duration time.Duration
+	}{
+		{
+			yaml: "duration: 0s\n",
+		},
+		{
+			yaml:     "duration: 0s\n",
+			duration: 0,
+		},
+		{
+			yaml:     "duration: 1m0s\n",
+			duration: time.Minute,
+		},
+	}
+
+	for index, test := range tests {
+		name := fmt.Sprintf("%d", index+1)
+		t.Run(name, func(t *testing.T) {
+			var cfg = config{
+				Duration: JSONDuration(test.duration),
+			}
+			yaml, err := yaml.Marshal(cfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.yaml, string(yaml))
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		yaml     string
+		duration time.Duration
+	}{
+		{
+			yaml:     "",
+			duration: 0,
+		},
+		{
+			yaml:     "duration: 0",
+			duration: 0,
+		},
+		{
+			yaml:     "duration: 60",
+			duration: time.Nanosecond * 60,
+		},
+		{
+			yaml:     "duration: 60s",
+			duration: time.Minute,
+		},
+	}
+
+	for index, test := range tests {
+		name := fmt.Sprintf("%d", index+1)
+		t.Run(name, func(t *testing.T) {
+			var cfg config
+			err := yaml.Unmarshal([]byte(test.yaml), &cfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.duration, cfg.Duration.Duration())
+		})
+	}
+}
+
+type config struct {
+	Duration JSONDuration `json:"duration"`
+}


### PR DESCRIPTION
Enabled the calendar integration to be more configurable. Specifically with "how long before a demo should we launch a cluster?". Additionally, add a field to disable the calendar integration, which is very helpful for testing.

```yaml
calendar:
  id: stackrox.com_32...30@resource.calendar.google.com
  window: 30m
  disabled: true
```

This PR also has a simple type (`JSONDuration`) that enables specifying durations in the human-friendly duration format (`3h12m`) instead of raw int64 nanoseconds 🙄. This type will probably be used in more places as time goes on.