### PR TITLE
Cluster list API filtering options

### DIFF
--- a/cmd/infractl/cluster/list/command.go
+++ b/cmd/infractl/cluster/list/command.go
@@ -37,8 +37,8 @@ func Command() *cobra.Command {
 }
 
 func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, _ []string) (common.PrettyPrinter, error) {
-	includeAll, _ := cmd.Flags().GetBool("all")
-	includeExpired, _ := cmd.Flags().GetBool("expired")
+	includeAll := common.MustBool(cmd.Flags(), "all")
+	includeExpired := common.MustBool(cmd.Flags(), "expired")
 
 	req := v1.ClusterListRequest{
 		All:     includeAll,

--- a/cmd/infractl/common/flags.go
+++ b/cmd/infractl/common/flags.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"github.com/spf13/cobra"
 )
 
@@ -62,4 +64,14 @@ func jsonOutput() bool {
 // token returns the given INFRACTL_TOKEN value.
 func token() string {
 	return flags.token
+}
+
+// MustBool looks up the named bool flag in the given flag set and panics if an
+// error is returned.
+func MustBool(flags *pflag.FlagSet, name string) bool {
+	value, err := flags.GetBool(name)
+	if err != nil {
+		panic(err)
+	}
+	return value
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/slack-go/slack v0.6.3
 	github.com/spf13/cobra v0.0.5
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasttemplate v1.1.0 // indirect
 	go.opencensus.io v0.22.1 // indirect

--- a/proto/api/v1/service.proto
+++ b/proto/api/v1/service.proto
@@ -246,13 +246,13 @@ message Cluster {
 
 // ClusterListRequest represents a request to ClusterService.List.
 message ClusterListRequest {
-    // All indicates that all clusters should be returned, not just the ones
+    // all indicates that all clusters should be returned, not just the ones
     // owned by the user.
-    bool All = 1;
+    bool all = 1;
 
-    // Expired indicates that expired clusters should be returned, not just the
+    // expired indicates that expired clusters should be returned, not just the
     // ones that are launching/ready.
-    bool Expired = 2;
+    bool expired = 2;
 }
 
 // ClusterListResponse represents details about all clusters.

--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -131,7 +131,7 @@ func (s *clusterImpl) List(ctx context.Context, request *v1.ClusterListRequest) 
 		email = svcacct.Email
 	}
 
-	clusters := make([]*v1.Cluster, 0)
+	clusters := make([]*v1.Cluster, 0, len(workflowList.Items))
 
 	// Loop over all of the workflows, and keep only the ones that match our
 	// request criteria.
@@ -144,13 +144,13 @@ func (s *clusterImpl) List(ctx context.Context, request *v1.ClusterListRequest) 
 
 		// This cluster is expired, and we did not request to include expired
 		// clusters.
-		if metacluster.Expired && !request.Expired {
+		if !request.Expired && metacluster.Expired {
 			continue
 		}
 
 		// This cluster is not ours, and we did not request to include all
 		// clusters.
-		if metacluster.Owner != email && !request.All {
+		if !request.All && metacluster.Owner != email {
 			continue
 		}
 

--- a/ui/src/generated/client/api.ts
+++ b/ui/src/generated/client/api.ts
@@ -770,8 +770,8 @@ export const ClusterServiceApiAxiosParamCreator = function (configuration?: Conf
     /**
      *
      * @summary CreateToken generates an arbitrary service account token
-     * @param {boolean} [all] All indicates that all clusters should be returned, not just the ones owned by the user.
-     * @param {boolean} [expired] Expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
+     * @param {boolean} [all] all indicates that all clusters should be returned, not just the ones owned by the user.
+     * @param {boolean} [expired] expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -787,11 +787,11 @@ export const ClusterServiceApiAxiosParamCreator = function (configuration?: Conf
       const localVarQueryParameter = {} as any;
 
       if (all !== undefined) {
-        localVarQueryParameter['All'] = all;
+        localVarQueryParameter['all'] = all;
       }
 
       if (expired !== undefined) {
-        localVarQueryParameter['Expired'] = expired;
+        localVarQueryParameter['expired'] = expired;
       }
 
       localVarUrlObj.query = {
@@ -986,8 +986,8 @@ export const ClusterServiceApiFp = function (configuration?: Configuration) {
     /**
      *
      * @summary CreateToken generates an arbitrary service account token
-     * @param {boolean} [all] All indicates that all clusters should be returned, not just the ones owned by the user.
-     * @param {boolean} [expired] Expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
+     * @param {boolean} [all] all indicates that all clusters should be returned, not just the ones owned by the user.
+     * @param {boolean} [expired] expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1095,8 +1095,8 @@ export const ClusterServiceApiFactory = function (
     /**
      *
      * @summary CreateToken generates an arbitrary service account token
-     * @param {boolean} [all] All indicates that all clusters should be returned, not just the ones owned by the user.
-     * @param {boolean} [expired] Expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
+     * @param {boolean} [all] all indicates that all clusters should be returned, not just the ones owned by the user.
+     * @param {boolean} [expired] expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1193,8 +1193,8 @@ export class ClusterServiceApi extends BaseAPI {
   /**
    *
    * @summary CreateToken generates an arbitrary service account token
-   * @param {boolean} [all] All indicates that all clusters should be returned, not just the ones owned by the user.
-   * @param {boolean} [expired] Expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
+   * @param {boolean} [all] all indicates that all clusters should be returned, not just the ones owned by the user.
+   * @param {boolean} [expired] expired indicates that expired clusters should be returned, not just the ones that are launching/ready.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof ClusterServiceApi


### PR DESCRIPTION
Including you @ikornienko as this is a breaking change to the cluster list API, in case you were working on a view for that.

Adds two filtering options to the cluster list API. The first includes clusters that are not owned by the calling user, and the second includes clusters that are expired. Implication is that by default the API now only returns clusters that are owned by the current user, and have not yet expired.