### PR TITLE
Enable dependabot for UI npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "ui/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "daily"
     reviewers:
       - "ikornienko"
+      - "vjwilson"


### PR DESCRIPTION
More of an experiment. It's hard to enable it on `rox` repo as we have so much outdated stuff that is not trivial to upgrade, yet here it should be no problem... in theory :)