### PR TITLE
Switch to initials built-in types

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import createInitials from 'initials';
+import { find as createInitials } from 'initials';
 
 type Props = {
   imageSrc?: string;

--- a/ui/src/types/README.md
+++ b/ui/src/types/README.md
@@ -1,0 +1,6 @@
+# TypeScript Type Definitions For External Dependencies
+
+If there is a library for which there are no types defined (neither in the
+library nor in the
+[DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/)),
+then those types should be added in this directory as `.d.ts` files.

--- a/ui/src/types/initials.d.ts
+++ b/ui/src/types/initials.d.ts
@@ -1,4 +1,0 @@
-declare module 'initials' {
-  function initials(name: string): string;
-  export = initials;
-}


### PR DESCRIPTION
They added types in `3.1.0`, so can kill our own that I defined before to satisfy strict TypeScript compiler settings.

I had to use `find` from `initials` because of how types are defined (see gr2m/initials#81). `find` is an alias for `initials` itself, i.e. it's kind of a method overloading with renaming :) It does take only `string` and returns always `string`.