### PR TITLE
Update dependabot cfg: schedule, reviewers, PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "ui/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+    open-pull-requests-limit: 10
     reviewers:
-      - "ikornienko"
-      - "vjwilson"
+      - "stackrox/ui"


### PR DESCRIPTION
Changes:
 - switch to weekly schedule
 - make reviewers the whole `@stackrox/ui` team (sorry @alanonthegit , you'll be getting it as well, let me know if it starts bothering you too much)
 - increase PR limit to 10 simultaneously opened (as now it's weekly, and default 5 might not be enough, and plus between all of the UI team we can handle more at one day :) )

Note: there is no way to have it run in 2 different days on a weekly basis as I originally wanted, so choosing Friday :) 