### PR TITLE
Use people as reviewers in dependabot cfg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,8 @@ updates:
       day: "friday"
     open-pull-requests-limit: 10
     reviewers:
-      - "stackrox/ui"
+      - "alwayshooin"
+      - "ikornienko"
+      - "pedrottimark"
+      - "sachaudh"
+      - "vjwilson"


### PR DESCRIPTION
Unfortunately, using teams as reviewers is only available in GitHub Enterprise per dear-github/dear-github#170 😢 

Therefore explicitly mentioning all of us in the dependendabot config. And in the meantime, I did what dependanbot was supposed to do: assigned us in #106 and #107 :) 