### PR TITLE
Update all automation flavor images

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -3,7 +3,7 @@
 ##########
 - id: demo
   name: StackRox Demo
-  description: Demo running StackRox 3.0.46.0
+  description: Demo running StackRox 3.0.47.2
   availability: default
   workflow: configuration/workflow-demo.yaml
   parameters:
@@ -12,15 +12,15 @@
       value: example1
 
     - name: main-image
-      value: stackrox.io/main:3.0.46.0
+      value: stackrox.io/main:3.0.47.2
       kind: hardcoded
 
     - name: scanner-image
-      value: stackrox.io/scanner:2.2.12
+      value: stackrox.io/scanner:2.3.1
       kind: hardcoded
 
     - name: scanner-db-image
-      value: stackrox.io/scanner-db:2.2.12
+      value: stackrox.io/scanner-db:2.3.1
       kind: hardcoded
 
   artifacts:
@@ -52,15 +52,15 @@
 
     - name: main-image
       description: StackRox Central image Docker name
-      value: stackrox.io/main:3.0.46.0
+      value: stackrox.io/main:3.0.47.2
 
     - name: scanner-image
       description: StackRox Scanner image Docker name
-      value: stackrox.io/scanner:2.2.12
+      value: stackrox.io/scanner:2.3.1
 
     - name: scanner-db-image
       description: StackRox Scanner DB image Docker name
-      value: stackrox.io/scanner-db:2.2.12
+      value: stackrox.io/scanner-db:2.3.1
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -112,7 +112,7 @@ spec:
             optional: true
 
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:v0.0.0-22-g7be8933
+        image: gcr.io/stackrox-infra/automation-flavors/demo:v0.0.0-27-g4924d62
         imagePullPolicy: Always
         args:
           - create
@@ -186,7 +186,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:v0.0.0-22-g7be8933
+        image: gcr.io/stackrox-infra/automation-flavors/demo:v0.0.0-27-g4924d62
         imagePullPolicy: Always
         args:
           - destroy

--- a/chart/infra-server/static/workflow-example.yaml
+++ b/chart/infra-server/static/workflow-example.yaml
@@ -47,7 +47,7 @@ spec:
           - name: success
 
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/example:v0.0.0-13-g1eb47b1
+        image: gcr.io/stackrox-infra/automation-flavors/example:v0.0.0-27-g4924d62
         args:
           - create
           - "--sleep={{inputs.parameters.sleep}}"
@@ -63,7 +63,7 @@ spec:
           - name: success
 
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/example:v0.0.0-13-g1eb47b1
+        image: gcr.io/stackrox-infra/automation-flavors/example:v0.0.0-27-g4924d62
         args:
           - destroy
           - "--sleep={{inputs.parameters.sleep}}"

--- a/chart/infra-server/static/workflow-gke-default.yaml
+++ b/chart/infra-server/static/workflow-gke-default.yaml
@@ -50,7 +50,7 @@ spec:
             valueFrom:
               path: /outputs/cluster_name
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/gke-default:v0.0.0-13-g1eb47b1
+        image: gcr.io/stackrox-infra/automation-flavors/gke-default:v0.0.0-27-g4924d62
         args:
           - create
           - "--name={{inputs.parameters.name}}"
@@ -67,7 +67,7 @@ spec:
         parameters:
           - name: name
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/gke-default:v0.0.0-13-g1eb47b1
+        image: gcr.io/stackrox-infra/automation-flavors/gke-default:v0.0.0-27-g4924d62
         args:
           - destroy
           - "--name={{inputs.parameters.name}}"

--- a/chart/infra-server/static/workflow-openshift-lite.yaml
+++ b/chart/infra-server/static/workflow-openshift-lite.yaml
@@ -45,7 +45,7 @@ spec:
           - name: terraform-destroy-plan
             path: /well-known/artifacts/terraform-destroy.tfplan
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-lite:v0.0.0-14-g4c82dc6
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-lite:v0.0.0-27-g4924d62
         args:
           - create
           - "--name={{inputs.parameters.name}}"
@@ -65,7 +65,7 @@ spec:
           - name: terraform-destroy-plan
             path: /well-known/artifacts/terraform-destroy.tfplan
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-lite:v0.0.0-14-g4c82dc6
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-lite:v0.0.0-27-g4924d62
         args:
           - destroy
         volumeMounts:

--- a/chart/infra-server/static/workflow-openshift-multi.yaml
+++ b/chart/infra-server/static/workflow-openshift-multi.yaml
@@ -49,7 +49,7 @@ spec:
           - name: terraform-destroy-plan
             path: /well-known/artifacts/terraform-destroy.tfplan
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-multi:v0.0.0-14-g4c82dc6
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-multi:v0.0.0-27-g4924d62
         args:
           - create
           - "--name={{inputs.parameters.name}}"
@@ -70,7 +70,7 @@ spec:
           - name: terraform-destroy-plan
             path: /well-known/artifacts/terraform-destroy.tfplan
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-multi:v0.0.0-14-g4c82dc6
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-multi:v0.0.0-27-g4924d62
         args:
           - destroy
         volumeMounts:


### PR DESCRIPTION
Grabbing images from this build: https://circleci.com/workflow-run/8a569191-831e-4a29-b787-86f733f35331

Includes fixes for many of the flavors, including:
- curl failures in demo
- openshift updates
- gke-default boot disk size