### PR TITLE
Test not linting yarn.lock

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -9,7 +9,7 @@ all: deps lint-check test build
 deps: package.json
 	yarn install --frozen-lockfile
 
-SOURCES := $(shell ls *.json) tailwind.config.js yarn.lock
+SOURCES := $(shell ls *.json) tailwind.config.js
 SOURCES += $(shell find public)
 SOURCES += $(shell find src -name '*.ts' -print)
 SOURCES += $(shell find src -name '*.tsx' -print)


### PR DESCRIPTION
Trying to get past Kevin's error when running `make -C ui/ all`

```
make[1]: *** No rule to make target `yarn.lock', needed by `lint-check'.  Stop.
make: *** [ui] Error 2
```