### PR TITLE
RS-98: use the supplied cluster name for the infra ID

### DIFF
--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -17,20 +17,20 @@ import (
 )
 
 const examples = `# Create a new "gke-default" cluster.
-$ infractl create gke-default --arg name=test --arg nodes=3
+$ infractl create gke-default you-20200921-1 --arg nodes=3
 
-# Create a new "gke-default" cluster with a 30 minute lifespan.
-$ infractl create gke-default --lifespan 30m --arg name=test --arg nodes=3`
+# Create another "gke-default" cluster with a 30 minute lifespan.
+$ infractl create gke-default you-20200921-2 --lifespan 30m --arg nodes=3`
 
 // Command defines the handler for infractl create.
 func Command() *cobra.Command {
 	// $ infractl create
 	cmd := &cobra.Command{
-		Use:     "create FLAVOR",
+		Use:     "create FLAVOR NAME",
 		Short:   "Create a new cluster",
 		Long:    "Creates a new cluster",
 		Example: examples,
-		Args:    common.ArgsWithHelp(cobra.ExactArgs(1), args),
+		Args:    common.ArgsWithHelp(cobra.ExactArgs(2), args),
 		RunE:    common.WithGRPCHandler(run),
 	}
 
@@ -45,6 +45,9 @@ func Command() *cobra.Command {
 func args(_ *cobra.Command, args []string) error {
 	if args[0] == "" {
 		return errors.New("no flavor ID given")
+	}
+	if args[1] == "" {
+		return errors.New("no cluster name given")
 	}
 	return nil
 }
@@ -72,6 +75,7 @@ func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, args []
 		}
 		req.Parameters[parts[0]] = parts[1]
 	}
+	req.Parameters["name"] = args[1]
 
 	clusterID, err := client.Create(ctx, &req)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -719,6 +719,7 @@ k8s.io/apimachinery v0.0.0-20191004115701-31ade1b30762/go.mod h1:Xc10RHc1U+F/e9G
 k8s.io/apimachinery v0.0.0-20191219145857-f69eda767ee8/go.mod h1:mhhO3hoLkWO+2eCvqjPtH2Ly92l9nJDwsswzWKpkN2w=
 k8s.io/apimachinery v0.16.7-beta.0 h1:1cNiN7ZXJzlWq7dnWojG5UcrX1AIfQqpbyuzhu7Bhsc=
 k8s.io/apimachinery v0.16.7-beta.0/go.mod h1:mhhO3hoLkWO+2eCvqjPtH2Ly92l9nJDwsswzWKpkN2w=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/client-go v0.0.0-20191225075139-73fd2ddc9180 h1:wubqwrdMGz+peAZ4BnIA9eRJnqx/Z9Y+QY7SIF6/duQ=
 k8s.io/client-go v0.0.0-20191225075139-73fd2ddc9180/go.mod h1:ksVkYlACXo9hR9AV+cYyCkuWL1xnWcGtAFxsfqMcozg=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -273,6 +273,11 @@ func (s *clusterImpl) create(req *v1.CreateClusterRequest, owner, eventID string
 	}
 	workflow.Spec.Arguments.Parameters = workflowParams
 
+	// Use the user supplied name as the Argo workflow name.
+	if name, ok := req.Parameters["name"]; ok {
+		workflow.ObjectMeta.Name = name
+	}
+
 	// Determine the lifespan for this cluster. Apply some sanity/bounds
 	// checking on provided lifespans.
 	lifespan, _ := ptypes.Duration(req.Lifespan)


### PR DESCRIPTION
https://stack-rox.atlassian.net/browse/RS-98

All infra flavors currently expect a name as an arg which is used by the cluster provider to uniquely name the cluster. This change uses that name as the infra ID for referring to the cluster in all future UI interactions. It also makes the name a required arg for create i.e. now `infractl create <flavor> <name>` instead of `infractl create <flavor> --arg name=<name>`.