### PR TITLE
Upgrade react-scripts to 4.0.1

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -18,6 +18,8 @@
 .env.test.local
 .env.production.local
 
+.eslintcache
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,7 @@
     "postcss": "^8.1.14",
     "postcss-cli": "^8.3.0",
     "prettier": "^2.2.0",
-    "react-scripts": "4.0.0",
+    "react-scripts": "^4.0.1",
     "tailwindcss": "^1.9.6",
     "typescript": "~3.9.7",
     "wait-on": "^5.2.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10139,7 +10139,7 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-dev-utils@^11.0.0:
+react-dev-utils@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.1.tgz#30106c2055acfd6b047d2dc478a85c356e66fe45"
   integrity sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==
@@ -10240,10 +10240,10 @@ react-router@6.0.0-beta.0:
   dependencies:
     prop-types "^15.7.2"
 
-react-scripts@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-4.0.0.tgz#36f3d84ffff708ac0618fd61e71eaaea11c26417"
-  integrity sha512-icJ/ctwV5XwITUOupBP9TUVGdWOqqZ0H08tbJ1kVC5VpNWYzEZ3e/x8axhV15ZXRsixLo27snwQE7B6Zd9J2Tg==
+react-scripts@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-4.0.1.tgz#34974c0f4cfdf1655906c95df6a04d80db8b88f0"
+  integrity sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
   dependencies:
     "@babel/core" "7.12.3"
     "@pmmmwh/react-refresh-webpack-plugin" "0.4.2"
@@ -10287,8 +10287,9 @@ react-scripts@4.0.0:
     postcss-normalize "8.0.1"
     postcss-preset-env "6.7.0"
     postcss-safe-parser "5.0.2"
+    prompts "2.4.0"
     react-app-polyfill "^2.0.0"
-    react-dev-utils "^11.0.0"
+    react-dev-utils "^11.0.1"
     react-refresh "^0.8.3"
     resolve "1.18.1"
     resolve-url-loader "^3.1.2"


### PR DESCRIPTION
Remember in #269 I said about not going to `react-scripts@4.0.1` because of facebook/create-react-app#10161? Oh well, it turned out we have to if we want to upgrade TypeScript to `4.1` 🤦 

So the problem AFAIU is that when one uses Quick Fix in VSCode, VSCode won't update `.eslintcache` and it's sometimes bad. I don't know how bad and how often. Guess we'll see, looks like some people are fine... maybe we'll be lucky ones? ;) 