### PR TITLE
RS-121: 3 nodes is better

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -95,7 +95,7 @@
 
     - name: nodes
       description: number of nodes
-      value: "2"
+      value: "3"
       kind: optional
 
     - name: machine-type


### PR DESCRIPTION
As per https://stack-rox.atlassian.net/browse/RS-121, a standard `./deploy/k8s/deploy.sh` install needs 3 nodes with gke-default.