### PR TITLE
Add support for adhoc dev infras

### DIFF
--- a/chart/infra-server/templates/certificate.yaml
+++ b/chart/infra-server/templates/certificate.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Values.deployment "local" -}}
 ---
 
 apiVersion: networking.gke.io/v1
@@ -11,3 +12,4 @@ spec:
   domains:
     - {{ .Values.hosts.primary }}
     - {{ .Values.hosts.secondary }}
+{{ end }}

--- a/chart/infra-server/templates/ingress.yaml
+++ b/chart/infra-server/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Values.deployment "local" -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 
@@ -9,8 +10,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.reservedAddressName }}
     networking.gke.io/managed-certificates: "infra-server-certificate"
-
 spec:
   backend:
     serviceName: infra-server-service
     servicePort: 8443
+{{ end }}

--- a/chart/infra-server/templates/namespace.yaml
+++ b/chart/infra-server/templates/namespace.yaml
@@ -3,4 +3,3 @@ kind: Namespace
 
 metadata:
   name: infra
-

--- a/chart/infra-server/templates/secrets.yaml
+++ b/chart/infra-server/templates/secrets.yaml
@@ -17,7 +17,7 @@ data:
     {{- .Files.Get "static/auth0.pem" | b64enc | nindent 4 }}
 
   auth0.yaml: |-
-    {{- include "require-file" (list "auth0.yaml" .) | b64enc | nindent 4 }}
+    {{- tpl (include "require-file" (list "auth0.yaml" .)) . | b64enc | nindent 4 }}
 
   cert.pem: |-
     {{- .Files.Get "static/tls-cert.pem" | b64enc | nindent 4 }}


### PR DESCRIPTION
This change allows one to deploy `infra` to an arbitrary k8s cluster. It does so by skipping the google managed cert and ingress provisioning that development (staging) and production infra require.

This change also ensures that the rendered YAML matches the deployment target. 

There is a change to configuration that you will need to download in order to use this.
