### PR TITLE
RS-125 add workflow-aks onExit template to enable workflow and cluster cleanup

### DIFF
--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: aks-
 spec:
   entrypoint: start
+  onExit: stop
   arguments:
     parameters:
       - name: name
@@ -27,6 +28,8 @@ spec:
         - - name: wait
             template: wait
 
+    - name: stop
+      steps:
         - - name: destroy
             template: destroy
 


### PR DESCRIPTION
I forgot to check that all workflows were covered by onExit handler after rebasing from latest master. So here is the fix for "aks" flavor.

To recap why this is needed... Infractl "delete" operation will resume the workflow from wait state, which then completes the workflow DAG, at which point the onExit "stop" handler runs, which invokes the "destroy" container template. Alternatively, if the infractl cleanup control loop detects an aberrant condition, it will manually delete the workflow via the argo workflow client interface, triggering the onExit handler.