### PR TITLE
Skip delete of failed workflow step (defer to Argo)

### DIFF
--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -528,8 +528,7 @@ func (s *clusterImpl) cleanupExpiredClusters() {
 			}
 
 			if metacluster.Status == v1.Status_FAILED {
-				log.Printf("[DEBUG] deleting workflow %q due to failed state", metacluster.ID)
-				s.ForceDeleteWorkflow(workflow)
+				log.Printf("[DEBUG] observed workflow %q failed state, cleanup deferred to Argo", metacluster.ID)
 				continue
 			}
 


### PR DESCRIPTION
Manual cleanup of the workflow should not be necessary, and precludes Argo workflow step retries. The trade-off is that we might leave failed workflows around until expiration time, but we gain the ability to pull log data from the failed pod so long as Argo hasn't cleaned up the pod.