### PR TITLE
RS-132: provide the DNS cert to automation via a GCS bucket

### DIFF
--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -95,7 +95,7 @@ spec:
             optional: true
 
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.0-1-gb6031167b8-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.1
         imagePullPolicy: Always
         args:
           - create
@@ -167,7 +167,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.0-1-gb6031167b8-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.1
         imagePullPolicy: Always
         args:
           - destroy

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -100,7 +100,7 @@ spec:
             optional: true
 
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.0-1-gb6031167b8-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.1
         imagePullPolicy: Always
         args:
           - create
@@ -174,7 +174,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.0-1-gb6031167b8-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/demo:0.2.1
         imagePullPolicy: Always
         args:
           - destroy


### PR DESCRIPTION
Demo (and qa-demo) clusters will get their DNS cert from [this](https://console.cloud.google.com/storage/browser/sr-demo-files/certs/demo.stackrox.com?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=ultra-current-825&prefix=&forceOnObjectsSortingFiltering=false) GCS bucket. Another PR will make the change to automate the cert renewal to that bucket.