### PR TITLE
Add toggle to not filter cluster list by user

### DIFF
--- a/ui/src/components/PageSection.tsx
+++ b/ui/src/components/PageSection.tsx
@@ -2,25 +2,18 @@ import React, { ReactElement, ReactNode } from 'react';
 
 type Props = {
   header: ReactNode;
-  headerComponents?: ReactNode;
   className?: string;
   children: ReactNode;
 };
 
-export default function PageSection({
-  header,
-  headerComponents = null,
-  className = '',
-  children,
-}: Props): ReactElement {
+export default function PageSection({ header, className = '', children }: Props): ReactElement {
   return (
     <div className="flex flex-col h-full min-h-0">
       <div className={`h-full overflow-auto ${className}`}>
-        <header className="flex justify-between items-center border-b-2 border-base-400 px-4 py-2">
+        <header className="border-b-2 border-base-400 px-4 py-2">
           <h2 className="bg-base-0 capitalize font-600 sticky text-4xl text-base-600 top-0">
             {header}
           </h2>
-          {headerComponents}
         </header>
         <div className="flex flex-col p-4">{children}</div>
       </div>

--- a/ui/src/containers/HomePage/MyClustersPageSection.tsx
+++ b/ui/src/containers/HomePage/MyClustersPageSection.tsx
@@ -34,6 +34,7 @@ type ClusterCardsProps = {
 
 function ClusterCards({ showAllClusters = false }: ClusterCardsProps): ReactElement {
   const { user } = useUserAuth();
+
   const { loading, error, data } = useApiQuery(fetchClusters);
 
   if (loading) {
@@ -53,9 +54,9 @@ function ClusterCards({ showAllClusters = false }: ClusterCardsProps): ReactElem
     ? data.Clusters
     : data.Clusters.filter((cluster) => cluster.Owner === user?.Email);
   // sorted in descending order by creation date
-  const sortedClusters = clustersToShow
-    .filter((cluster) => cluster.Owner === user?.Email)
-    .sort((c1, c2) => (moment(c1.CreatedOn).isBefore(c2.CreatedOn) ? 1 : -1));
+  const sortedClusters = clustersToShow.sort((c1, c2) =>
+    moment(c1.CreatedOn).isBefore(c2.CreatedOn) ? 1 : -1
+  );
 
   if (sortedClusters.length === 0) {
     return <NoClustersMessage />;
@@ -63,13 +64,15 @@ function ClusterCards({ showAllClusters = false }: ClusterCardsProps): ReactElem
 
   const cards = sortedClusters.map((cluster) => {
     assertDefined(cluster.ID);
+
+    const extraCardClass = showAllClusters && cluster.Owner === user?.Email ? 'bg-base-200' : '';
     return (
       <LinkCard
         key={cluster.ID}
         to={`cluster/${cluster.ID}`}
         header={cluster.ID || 'No ID'}
         footer={cluster.Status && <Lifespan cluster={cluster} />}
-        className="m-2"
+        className={`m-2 ${extraCardClass}`}
       >
         {cluster.Description && (
           <span className="mb-2 text-lg">Description: {cluster.Description}</span>
@@ -88,9 +91,10 @@ export default function LaunchPageSection(): ReactElement {
     setShowAllClusters(!showAllClusters);
   }
 
+  const headerText = showAllClusters ? 'All Clusters' : 'My Clusters';
   const clusterFilterToggle = (
     <span className="flex items-center">
-      <label htmlFor="cluster-filter-toggle" className="mr-2">
+      <label htmlFor="cluster-filter-toggle" className="mr-2 text-lg">
         Show All Clusters
       </label>
       <input
@@ -98,12 +102,19 @@ export default function LaunchPageSection(): ReactElement {
         id="cluster-filter-toggle"
         checked={showAllClusters}
         onChange={toggleClusterFilter}
+        className="w-4 h-4 rounded-sm"
       />
     </span>
   );
 
+  const header = (
+    <div className="flex justify-between items-center ">
+      <span>{headerText}</span>
+      {clusterFilterToggle}
+    </div>
+  );
   return (
-    <PageSection header="My Clusters" headerComponents={clusterFilterToggle}>
+    <PageSection header={header}>
       <div className="flex flex-wrap -m-2">
         <ClusterCards showAllClusters={showAllClusters} />
       </div>


### PR DESCRIPTION
The way we were filtering on the FE already led me to believe that this would be the easiest of Gaurav's asks for the Hackathon.

With new toggle OFF, same behavior:
![Screen Shot 2021-02-10 at 2 12 54 PM](https://user-images.githubusercontent.com/715729/107559833-93032000-6baa-11eb-80b0-20879370cafe.png)

With new toggle ON, should see all currently running clusters, but API does not return them yet:
![Screen Shot 2021-02-10 at 2 13 00 PM](https://user-images.githubusercontent.com/715729/107559855-99919780-6baa-11eb-81ce-9367f5dbedff.png)
