### PR TITLE
fix argo server crash loop

### DIFF
--- a/chart/infra-server/templates/argo/secrets.yaml
+++ b/chart/infra-server/templates/argo/secrets.yaml
@@ -21,8 +21,6 @@ data:
       metadata:
         annotations:
           argo: workflows
-        labels:
-          infra: true
       spec:
         ttlStrategy:
           secondsAfterCompletion: 86400


### PR DESCRIPTION
The argo-server is crash looping with:

```
time="2021-03-03T23:49:06.223Z" level=fatal msg="error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into Go struct field ObjectMeta.workflowDefaults.metadata.labels of type string"
```

This change removes the label that was causing it. The label does not appear to be necessary for a functioning infra.
