### PR TITLE
RS-119: make crio optional

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -181,6 +181,7 @@
     - name: crio
       description: should CRI-O be used as the container runtime
       value: true
+      kind: optional
 
     - name: zone
       description: Google Cloud zone to deploy infrastructure into.


### PR DESCRIPTION
Making crio an optional parameter (at the flavor level) fixes the web UX issue where the user had to enter a crio value. Also because optional flavor parameters are populated in the cluster form this change indicates that it should be a true/false value.