### PR TITLE
make GKE default to stable

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -110,9 +110,11 @@
       kind: optional
 
     - name: k8s-version
-      description: kubernetes version
-      value: latest
+      description: GKE kubernetes version
+      value: ""
       kind: optional
+      help: |
+        e.g. 1.19.12-gke.2100. Use 'gcloud container get-server-config --zone=us-central1' to see all versions.
 
     - name: pod-security-policy
       description: Enables the pod security policy admission controller for the cluster


### PR DESCRIPTION
Using a default of 'latest' for GKE --cluster-version can cause [instability](https://srox.slack.com/archives/CMH5M8MHN/p1628517889080500) and does not align with clusters created in CI which use the stable channel. This change will cause infra to use the stable channel by default.

Tested in https://dev.infra.rox.systems/, looks good.