### PR TITLE
Update infra to use version 64 for new demo instances

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -3,7 +3,7 @@
 ##########
 - id: demo
   name: StackRox Demo
-  description: Demo running StackRox 3.0.64.0
+  description: Demo running StackRox 3.64.0
   availability: default
   workflow: configuration/workflow-demo.yaml
   parameters:
@@ -12,7 +12,7 @@
       value: example1
 
     - name: main-image
-      value: stackrox.io/main:3.0.64.0
+      value: stackrox.io/main:3.64.0
       kind: hardcoded
 
     - name: k8s-version
@@ -51,8 +51,8 @@
 
     - name: main-image
       description: StackRox Central image Docker name
-      value: stackrox.io/main:3.0.64.0
-      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.0.64.0
+      value: stackrox.io/main:3.64.0
+      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.64.0
 
     - name: scanner-image
       description: StackRox Scanner image Docker name


### PR DESCRIPTION
I think this is all I need to do.

(I noticed infra was still using 62 for the demo option, when I spun up a cluster for Andrew Ronaldson Red Hat Design team to take a look at. https://vw0818sourentrypresent.demo.stackrox.com/main/dashboard )
