### PR TITLE
Use os.Executable() for upgrade path

### DIFF
--- a/cmd/infractl/cli/upgrade/command.go
+++ b/cmd/infractl/cli/upgrade/command.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -134,7 +133,7 @@ func writeToTempFileAndTest(bytes []byte) (string, error) {
 }
 
 func moveIntoPlace(tempFilename string) (string, error) {
-	infractlFilename, err := filepath.Abs(os.Args[0])
+	infractlFilename, err := os.Executable()
 	if err != nil {
 		return "", errors.Wrap(err, "Cannot determine infractl path")
 	}


### PR DESCRIPTION
filepath.Abs(os.Args[0]) gives the CWD + infractl.

[SO](https://stackoverflow.com/questions/18537257/how-to-get-the-directory-of-the-currently-running-file) + manual tests suggests that os.Executable() works better.