### PR TITLE
Update infra to use version 66 for new demo instances

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -3,7 +3,7 @@
 ##########
 - id: demo
   name: StackRox Demo
-  description: Demo running StackRox 3.65.0
+  description: Demo running StackRox 3.66.0
   availability: default
   workflow: configuration/workflow-demo.yaml
   parameters:
@@ -12,7 +12,7 @@
       value: example1
 
     - name: main-image
-      value: stackrox.io/main:3.65.0
+      value: stackrox.io/main:3.66.0
       kind: hardcoded
 
     - name: k8s-version
@@ -51,8 +51,8 @@
 
     - name: main-image
       description: StackRox Central image Docker name
-      value: stackrox.io/main:3.65.0
-      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.65.0
+      value: stackrox.io/main:3.66.0
+      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.66.0
 
     - name: scanner-image
       description: StackRox Scanner image Docker name


### PR DESCRIPTION
Catching up the version that infra uses when you request a demo instance.

@misberner, Tagging you because of the discussion about moving to Quay here,
https://srox.slack.com/archives/C01ANN16YF5/p1635762365001600

Not sure if we need to to anything for that in Infra, or if what it currently uses, `stackrox.io` will be re-mapped to Quay.