### PR TITLE
RS-408 infractl fix

### DIFF
--- a/cmd/infractl/cli/upgrade/command.go
+++ b/cmd/infractl/cli/upgrade/command.go
@@ -199,7 +199,7 @@ func moveIntoPlace(tempFilename string) (string, error) {
 		return "", errors.Wrap(err, "Cannot move the download into place")
 	}
 
-	err = os.Chmod(infractlFilename, 0777)
+	err = os.Chmod(infractlFilename, 0755)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/RS-408

os.Rename() was failing to move the new binary from `/tmp` filesystem to `/` filesystem since it was a cross-device move on Fedora. This change copies the new binary to the target location with ".staged" file extension before performing os.Rename().

### Testing

    $ cd /go/src/github.com/stackrox/infra
    $ make cli-local && infractl version && infractl cli upgrade && infractl version

    Client
      Version:    0.2.19-2-g00c720e
      Commit:     00c720e
      Workflow:   local
      Build Date: 2022-01-08 00:41:24 +0000 UTC
      Go Version: go1.17.2
      Platform:   linux/amd64
    Server
      Version:    0.2.19
      Commit:     49960e7
      Workflow:   local
      Build Date: 2022-01-06 01:27:29 +0000 UTC
      Go Version: go1.17.5
      Platform:   linux/amd64

    ---
    infractl and infra-server versions are different.
    0.2.19-2-g00c720e -v- 0.2.19
    You can use `infractl cli upgrade` to update.
    ---

    Updated /usr/bin/infractl to match the infra server version

    Client
      Version:    0.2.19
      Commit:     49960e7
      Workflow:   local
      Build Date: 2022-01-06 01:27:40 +0000 UTC
      Go Version: go1.17.5
      Platform:   linux/amd64
    Server
      Version:    0.2.19
      Commit:     49960e7
      Workflow:   local
      Build Date: 2022-01-06 01:27:29 +0000 UTC
      Go Version: go1.17.5
      Platform:   linux/amd64
