### PR TITLE
RS-450 use latest openshift-osd image with latest ocm cli

### DIFF
--- a/chart/infra-server/static/workflow-osd-aws.yaml
+++ b/chart/infra-server/static/workflow-osd-aws.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.17-2-gb92f5a842e-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.18
         imagePullPolicy: Always
         args:
           - aws
@@ -104,7 +104,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.17-2-gb92f5a842e-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.18
         imagePullPolicy: Always
         args:
           - aws

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.17-2-gb92f5a842e-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.18
         imagePullPolicy: Always
         args:
           - gcp
@@ -101,7 +101,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.17-2-gb92f5a842e-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.18
         imagePullPolicy: Always
         args:
           - gcp


### PR DESCRIPTION
This PR updates OSD provisioner to 0.2.18 to fix OSD.

### Testing
Tested (gke-default, kops, eks, rosa, osd-on-gcp, osd-on-aws, aro) on https://dev.infra.rox.systems/ 

### References
* https://issues.redhat.com/browse/RS-450
* https://github.com/stackrox/automation-flavors/releases/tag/0.2.18