### PR TITLE
Fix GKE cluster create

### DIFF
--- a/chart/infra-server/static/workflow-gke-default.yaml
+++ b/chart/infra-server/static/workflow-gke-default.yaml
@@ -58,7 +58,7 @@ spec:
             valueFrom:
               path: /outputs/cluster_name
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/gke-default:0.2.16
+        image: gcr.io/stackrox-infra/automation-flavors/gke-default:0.2.19
         imagePullPolicy: Always
         args:
           - create
@@ -81,7 +81,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/gke-default:0.2.16
+        image: gcr.io/stackrox-infra/automation-flavors/gke-default:0.2.19
         imagePullPolicy: Always
         args:
           - destroy


### PR DESCRIPTION
Note: I manually built and pushed an updated gke-default due to unrelated alpine download issues in automation-flavors demo.

```
make build-gke-default CIRCLE_TAG=0.2.19
make push-gke-default CIRCLE_TAG=0.2.19
```
