### PR TITLE
Update infra to use version 68.1 for new demo instances

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -3,7 +3,7 @@
 ##########
 - id: demo
   name: StackRox Demo
-  description: Demo running StackRox 3.67.2
+  description: Demo running StackRox 3.68.1
   availability: default
   workflow: configuration/workflow-demo.yaml
   parameters:
@@ -12,7 +12,7 @@
       value: example1
 
     - name: main-image
-      value: stackrox.io/main:3.67.2
+      value: stackrox.io/main:3.68.1
       kind: hardcoded
 
     - name: k8s-version
@@ -51,8 +51,8 @@
 
     - name: main-image
       description: StackRox Central image Docker name
-      value: stackrox.io/main:3.67.2
-      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.67.2
+      value: stackrox.io/main:3.68.1
+      help: This must be a fully qualified image e.g. docker.io/stackrox/main:3.68.1
 
     - name: scanner-image
       description: StackRox Scanner image Docker name


### PR DESCRIPTION
We should automate this workflow and tie it to the release. 🦖 