### PR TITLE
ROX-9228 Add diagnostics collection to OpenShift 4.6 provision failures

### DIFF
--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -74,7 +74,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-4:0.2.18-35-gdd80648215-snapshot:
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-4:0.2.18-35-gdd80648215-snapshot
         imagePullPolicy: Always
         args:
           - create
@@ -115,7 +115,7 @@ spec:
 
     - name: destroy
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-4:0.2.18-35-gdd80648215-snapshot:
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-4:0.2.18-35-gdd80648215-snapshot
         imagePullPolicy: Always
         args:
           - destroy


### PR DESCRIPTION
ROX-9228 Add diagnostics collection to OpenShift 4.6 provision failures

Not planning to roll this out right away -- probably wait for next https://github.com/stackrox/automation-flavors/releases.

### Testing

Tested OpenShift-4 with "ocp/4.6.54" in https://dev.infra.rox.systems/ (0.2.21-3-g1822fe4).
Same _automation-flavor_ image as was tested for https://github.com/stackrox/stackrox/pull/672/files.
