### PR TITLE
Fix OSD provisioner failure on GCP

### DIFF
--- a/chart/infra-server/static/workflow-osd-aws.yaml
+++ b/chart/infra-server/static/workflow-osd-aws.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.19-15-g6fece3fa4d-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.20
         imagePullPolicy: Always
         args:
           - aws
@@ -104,7 +104,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.19-15-g6fece3fa4d-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.20
         imagePullPolicy: Always
         args:
           - aws

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.19-15-g6fece3fa4d-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.20
         imagePullPolicy: Always
         args:
           - gcp
@@ -101,7 +101,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.19-15-g6fece3fa4d-snapshot
+        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.20
         imagePullPolicy: Always
         args:
           - gcp


### PR DESCRIPTION
* Fix OSD provisioner failure on GCP
* https://github.com/stackrox/automation-flavors/pull/90

### Testing
* tested locally and in dev infra
* then bumped openshift-osd image version to 0.2.20 corresponding to forthcoming automation-flavors release