### PR TITLE
Truncate names to 29 characters max

### DIFF
--- a/ui/src/utils/cluster.utils.ts
+++ b/ui/src/utils/cluster.utils.ts
@@ -19,6 +19,9 @@ export function generateClusterName(username = ''): string {
   // prepare to combine, but filter any empty part (only one that should ever be empty is user string)
   const nameArray = [userPart, datePart, randomPart].filter(Boolean);
 
-  // combine the 3 parts,, and truncate it at 40 characters, to keep it within the GCP limit
-  return nameArray.join('-').slice(0, 40);
+  // combine the 3 parts, truncate it at 29 characters, and remove a trailing '-', if any.
+  // Truncation is needed to allow generating wildcard certificates for OpenShift using Let's Encrypt: since LE insists
+  // on the domain forming the Common Name of the certificate, the string '*.apps.<name>.openshift.infra.rox.systems'
+  // must not exceed 64 characters. This leaves a budget of 29 characters for the <name> portion.
+  return nameArray.join('-').slice(0, 29).replace(/-$/, "");
 }


### PR DESCRIPTION
See the comment for an explanation of why this is ~necessary~ more convenient.