### PR TITLE
Use new quay ro creds to pull apollo-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ storeGitHubPackageRegistryNpmToken: &storeGitHubPackageRegistryNpmToken
 executors:
   custom:
     docker:
-      - image: quay.io/cgorman1/apollo-ci:0.3.13
+      - image: quay.io/rhacs-eng/apollo-ci:0.3.13
         auth:
           username: $QUAY_RHACS_ENG_RO_USERNAME
           password: $QUAY_RHACS_ENG_RO_PASSWORD


### PR DESCRIPTION
Broken CI build after removing old quay ro credentials:
https://app.circleci.com/pipelines/github/stackrox/infra/2734/workflows/74fd4b47-77f8-45b9-9178-40ae7f73961c

CircleCI Contexts:
https://app.circleci.com/settings/organization/github/stackrox/contexts/8c5222d1-2693-45dd-8d8e-b6dbcb3e3bed

Already have appropriate context. So just need to update the auth vars.