### PR TITLE
Allow anonymous infractl download

### DIFF
--- a/service/cli.go
+++ b/service/cli.go
@@ -69,7 +69,7 @@ func (s *cliImpl) Upgrade(request *v1.CliUpgradeRequest, stream v1.CliService_Up
 // Access configures access for this service.
 func (s *cliImpl) Access() map[string]middleware.Access {
 	return map[string]middleware.Access{
-		"/v1.CliUpgradeService/Download": middleware.Authenticated,
+		"/v1.CliUpgradeService/Download": middleware.Anonymous,
 	}
 }
 


### PR DESCRIPTION
Release automation would be greatly simplified thanks to the `infractl` tool, if it could be downloaded anonymously.
A robotic token to be setup for the following operations.