### PR TITLE
Get roxctl for demo installs

### DIFF
--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -54,13 +54,17 @@ spec:
       outputs:
         artifacts:
           - name: roxctl
-            path: /stackrox/roxctl
+            path: /tmp/roxctl
       container:
         image: "{{workflow.parameters.main-image}}"
         imagePullPolicy: Always
+        command:
+          - cp
         args:
-          - version
-          - "--json"
+          - --dereference
+          - -v
+          - /stackrox/roxctl
+          - /tmp/roxctl
 
     - name: create
       activeDeadlineSeconds: 3600

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -59,13 +59,17 @@ spec:
       outputs:
         artifacts:
           - name: roxctl
-            path: /stackrox/roxctl
+            path: /tmp/roxctl
       container:
         image: "{{workflow.parameters.main-image}}"
         imagePullPolicy: Always
+        command:
+          - cp
         args:
-          - version
-          - "--json"
+          - --dereference
+          - -v
+          - /stackrox/roxctl
+          - /tmp/roxctl
 
     - name: create
       activeDeadlineSeconds: 3600


### PR DESCRIPTION
Due to the roxctl filename changes for multiarch support `/assets/downloads/cli/roxctl-linux` is no longer available as a source of roxctl required for demo installs. `/stackrox/linux` is available as a backwardly compatible linux-amd64 source if copied following the symlink.
