### PR TITLE
Improve tools dependency management

### DIFF
--- a/.github/workflows/lint-build-push.yaml
+++ b/.github/workflows/lint-build-push.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Setup env
         run: |
+          sudo apt-get install protobuf-compiler -y
           GOPATH="$GITHUB_WORKSPACE/go"
           echo GOPATH="${GOPATH}" >> $GITHUB_ENV
           PATH="${PATH}:${GOPATH}/bin"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@
 
 Infra (the server) and infractl (the cli) are written in Go, and use gRPC for client-server communication.
 
+### Dependencies
+
+The protobuf compiler is required to generate required Go code.
+
+For macOS:
+
+`brew install protobuf`
+
+For Red Hat-based Linux distributions:
+
+`dnf install protobuf-compiler`
+
+For all operating systems, you can download a pre-built binary from the official protobuf project's release page:
+
+https://github.com/protocolbuffers/protobuf/releases
+
 ### Regenerate Go bindings from protos
 
 To regenerate the Go proto bindings, run:

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	google.golang.org/api v0.70.0
 	google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c
 	google.golang.org/grpc v1.44.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1791,6 +1792,7 @@ google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/proto/api/v1/service.proto
+++ b/proto/api/v1/service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "v1";
+option go_package = "./api/v1";
 
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,10 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
+	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+)


### PR DESCRIPTION
This change removes installing the protobuf compiler and the required plugins and uses go modules for better and more consistent dependency management for those tools.