### PR TITLE
update dependabot to include go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,6 @@ updates:
     reviewers:
       - 'gavin-stackrox'
       - 'RTann'
+      - 'BradLugo'
+      - 'house-d'
+      - 'tommartensen'


### PR DESCRIPTION
Feel free to add anyone else or make a group on GitHub which should be used instead