### PR TITLE
fix deploy: set shell to bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ifndef ENVIRONMENT
 	$(error ENVIRONMENT is undefined)
 endif
 	@if [[ "${DEPLOYMENT}" == "local" && ("${this_context}" == "${dev_context}" || "${this_context}" == "${prod_context}") ]]; then \
-		echo -e "Your kube context is not set to a local infra!"; \
+		echo "Your kube context is not set to a local infra!"; \
 		exit 1; \
 	fi
 	@if [[ "${DEPLOYMENT}" == "development" && "${this_context}" != "${dev_context}" ]]; then \


### PR DESCRIPTION
Proof deployment to dev.infra.rox.systems: https://github.com/stackrox/infra/actions/runs/3384115214/jobs/5620707764

This didn't surface in the PR deployment, possible reason: We use a special image `quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.51` to run the Make commands there. 

By default, Make will take the value of the `SHELL` env var to run shell commands with fallback to `sh`, my guess is that it was set in this image, and not in the default image. 