### PR TITLE
fix: don't allow roxbot changes to run the critical parts of the PR workflow

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -34,12 +34,12 @@ jobs:
             --body "Reviewers, please check this PR and add label \`dependabot/ok-to-test\` if you want dependabot to test the changes."
 
   build-and-push:
-    if: ${{ !contains(fromJson('["dependabot[bot]", "roxbot"]'), github.actor)  || (github.actor == 'dependabot[bot]' && contains(toJson(github.event.pull_request.labels.*.name), 'dependabot/ok-to-test')) }}
+    if: ${{ !contains(fromJson('["dependabot[bot]", "roxbot"]'), github.actor) || (github.actor == 'dependabot[bot]' && contains(toJson(github.event.pull_request.labels.*.name), 'dependabot/ok-to-test')) }}
     uses: ./.github/workflows/build-and-push.yaml
     secrets: inherit
 
   create-dev-cluster:
-    if: ${{ !contains(fromJson('["dependabot[bot]", "roxbot"]'), github.actor)  || (github.actor == 'dependabot[bot]' && contains(toJson(github.event.pull_request.labels.*.name), 'dependabot/ok-to-test')) }}
+    if: ${{ !contains(fromJson('["dependabot[bot]", "roxbot"]'), github.actor) || (github.actor == 'dependabot[bot]' && contains(toJson(github.event.pull_request.labels.*.name), 'dependabot/ok-to-test')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: stackrox/actions/infra/create-cluster@v1


### PR DESCRIPTION
A bug I found in https://github.com/stackrox/infra/actions/runs/3480701004/jobs/5821007634. 

`roxbot` is adding the `needs-review` label, which triggers a workflow run. 
I rewrote the condition under which the container build + and cluster provisioning are executed, so this workflow run (or any other triggered by roxbot) only does linting. 
If left unfixed, we'd still be exploitable to supply chain attacks through compromised dependencies. 