### PR TITLE
simple token exclusion

### DIFF
--- a/auth/tokenizer.go
+++ b/auth/tokenizer.go
@@ -123,8 +123,8 @@ type oidcClaims struct {
 // Specifically, it enforces users to have verified email addresses and that
 // those email addresses are from the allowed domains.
 func (c oidcClaims) Valid() error {
-	_, ok := excludedEmails[c.Email]
-	if !ok {
+	_, isExcluded := excludedEmails[c.Email]
+	if isExcluded {
 		return errors.New("email address is excluded")
 	}
 	switch {
@@ -224,7 +224,8 @@ func (t userTokenizer) Validate(token string) (*v1.User, error) {
 type serviceAccountValidator v1.ServiceAccount
 
 func (s serviceAccountValidator) Valid() error {
-	if _, ok := excludedEmails[s.Email]; ok {
+	_, isExcluded := excludedEmails[s.Email]
+	if isExcluded {
 		return errors.New("email address is excluded")
 	}
 	switch {


### PR DESCRIPTION
This PR is a minimal exclusion for the 'infra@stackrox.com' token to handle potential #incident-circle-ci exposure.
A fuller examination of infra tokens can be addressed by https://issues.redhat.com/browse/ROX-14317

Tested with:
```
$ INFRA_TOKEN=... bin/infractl -k -e localhost:8443 list
Error: rpc error: code = PermissionDenied desc = access denied
$ bin/infractl -k -e localhost:8443 whoami
Service Account
  Name:        Gavin Jefferies
  Description: Personal service account for gjefferi@redhat.com
  Email:       gjefferi@redhat.com
```