### PR TITLE
fix release notifications and progress CHANGELOG for 0.7.1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -60,7 +60,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: CVANK5K5W #infra
+          channel-id: C01H4DC33K3 #acs-infra
           payload: >-
             {
                 "blocks": [
@@ -68,7 +68,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": ":ship::tada:*Infra (${{ inputs.environment }}) was updated to ${{ inputs.version }}.*\nTo see the latest changes, click <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.version }}|here>."
+                      "text": ":ship::tada:*Infra (${{ inputs.environment }}) was updated to ${{ inputs.version }}.*\nTo see the latest changes, click <${{ github.server_url }}/${{ github.repository }}/blob/${{ inputs.version }}/CHANGELOG.md|here>."
                     }
                   }
                 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.7.1]
+
 - ROX-15237: The Openshift 4 Demo flavor now supports testing of unreleased versions.
 - Bump demo flavors to 3.74.2
 - Add central-db-image parameter to qa-demo flavor


### PR DESCRIPTION
Failed notification: https://github.com/stackrox/infra/actions/runs/4689814143/jobs/8312051363. 
Channel ID is updated (changed during Slack migration), also updated the SLACK_BOT_TOKEN (Bitwarden: Release Automation Slack Bot Token).

