### PR TITLE
ROX-17273: Change defaults for openshift-4 to support rhacs-operator ACS installs

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -273,7 +273,7 @@
 
     - name: master-node-type
       description: the type of master nodes
-      value: n1-standard-4
+      value: e2-standard-4
       kind: optional
 
     - name: master-node-count
@@ -283,12 +283,12 @@
 
     - name: worker-node-type
       description: the type of worker nodes
-      value: n1-standard-4
+      value: e2-standard-8
       kind: optional
 
     - name: worker-node-count
       description: number of worker nodes
-      value: 4
+      value: 2
       kind: optional
 
     - name: region


### PR DESCRIPTION
A default 4.0 ACS install via the rhacs-operator requires larger worker nodes. This change also switches to the preferred `e2-` node type. https://redhat-internal.slack.com/archives/CVANK5K5W/p1685067576326429