### PR TITLE
Don't run CI when PRs are labeled

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - synchronize
-      - labeled
 
 defaults:
   run:


### PR DESCRIPTION
When dependabot opens PRs it adds two labels which means we get three simultaneous PR.yaml actions which usually fail as they run against the same dev infra instance. Running CI based on labeling was useful when dependabot did not have permission to run CI but not so much now due to this bug.