### PR TITLE
run build and push workflow also on master

### DIFF
--- a/.github/workflows/ReleaseTagged.yaml
+++ b/.github/workflows/ReleaseTagged.yaml
@@ -2,6 +2,8 @@ name: Release Tagged
 
 on:
   push:
+    branches:
+      - master
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
 


### PR DESCRIPTION
We actually don't build images for master commits. 
That would be helpful to deploy master branch to the dev.infra.rox.systems staging environment, without having to create a fake tag. 