### PR TITLE
Make demo DNS configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- Make the domain for GKE based demos configurable.
+
 ## [0.7.10]
 - Fix for openshift-4-demo 4.2+ installs
 - Reduce the master node count of openshift-4 and openshift-4-demo flavors from

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -112,7 +112,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.10-1-g380141d7bc-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.11
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -188,7 +188,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.10-1-g380141d7bc-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.11
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -116,7 +116,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.10-1-g380141d7bc-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.11
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -194,7 +194,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.10-1-g380141d7bc-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.7.11
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint


### PR DESCRIPTION
Uses https://github.com/stackrox/automation-flavors/pull/148. 

## Tests

### with commit at https://github.com/stackrox/infra/pull/965/commits/c7fa82d23f9e1a68a82af7fc10db196dca0f5b54

- [x] create a demo in blah.demos.rox.systems

Works! https://gj08291.demos.rox.systems/main/dashboard (except certs, which is one reason to keep and move demo.stackrox.com)

- [x] delete and verify domain is deleted

### with commit at https://github.com/stackrox/infra/pull/965/commits/fc1a7d3cc260ff718d804bbe00d72f82fa5b9466

- [x] create a qa demo in blah.demo.stackrox.com

- [x] delete and verify domain is deleted
