### PR TITLE
Create a certifier for demos.rox.systems

### DIFF
--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -78,7 +78,7 @@ spec:
             path: /certs/cert.pem
             gcs:
               bucket: sr-demo-files
-              key: certs/demos.rox.systems/privkey-plus-fullchain.pem
+              key: certs/demo.stackrox.com/privkey-plus-fullchain.pem
               serviceAccountKeySecret:
                 name: google-credentials-demo
                 key: google-credentials.json
@@ -170,9 +170,9 @@ spec:
                 name: demo-secrets
                 key: SLACK_WEBHOOK
           - name: GCP_CLOUD_DNS_ZONE_NAME
-            value: "demos-rox-systems"
+            value: "demo-stackrox-com"
           - name: DOMAIN_NAME
-            value: "demos.rox-systems"
+            value: "demo.stackrox.com"
 
     - name: wait
       suspend: {}


### PR DESCRIPTION
This creates a certifier cronjob for `*.demos.rox.systems` similar to what exists for `*.demo.stackrox.com`. 

I ran it as a one off job on the initial commit: fba9002f632908b606c92a557bb09ebea255c706 with `kubectl -n infra create job --from=cronjob/demo-certifier dc1`. This created the initial cert and populated the certs bucket.

Tested with a temporary change to demo on commit b36febae57e313bb84d01fb6dcc1c1ed4fc93d10.
![Screenshot_2023-08-31_19-23-48](https://github.com/stackrox/infra/assets/64558589/8681372e-86ea-41c0-b98f-d4761f461c69)

