### PR TITLE
Change the OpenShift-4 master node count from 1 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ## [NEXT RELEASE]
 
 - Make the domain for GKE based demos configurable.
+- Revert the change that reduced the master node count of openshift-4 and openshift-4-demo flavors from
+  3 to 1 (default is now 3 again).
 
 ## [0.7.10]
 - Fix for openshift-4-demo 4.2+ installs

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -279,7 +279,7 @@
 
     - name: master-node-count
       description: number of master nodes
-      value: 1
+      value: 3
       kind: optional
 
     - name: worker-node-type

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -101,7 +101,7 @@ spec:
           - name: OPENSHIFT_VERSION
             value: "{{workflow.parameters.openshift-version}}"
           - name: MASTER_NODE_COUNT
-            value: "1"
+            value: "3"
           - name: WORKER_NODE_COUNT
             value: "3"
           - name: MASTER_NODE_TYPE


### PR DESCRIPTION
Essentially reverts https://github.com/stackrox/infra/pull/950

We saw an issue with openshift certificates after stressing the clusters with a single control plane node. See this Slack thread for more context on the issue: https://redhat-internal.slack.com/archives/CVANK5K5W/p1693347808353169