### PR TITLE
ROX-19609: add cluster name validation to infractl

### DIFF
--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -164,7 +164,7 @@ func validateName(name string) error {
 		return err
 	}
 	if !match {
-		return errors.New("The name does not match its requirements. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.")
+		return errors.New("The name does not match the requirements. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.")
 	}
 
 	return nil

--- a/cmd/infractl/cluster/create/create.bats
+++ b/cmd/infractl/cluster/create/create.bats
@@ -138,7 +138,7 @@ setup() {
 @test "provided name failed validation because does not match regex" {
   run infractl create test-qa-demo THIS-IN-INVALID
   assert_failure
-  assert_output --partial "Error: The name does not match its requirements."
+  assert_output --partial "Error: The name does not match the requirements."
 }
 
 infractl() {


### PR DESCRIPTION
This was a user request: https://issues.redhat.com/browse/ROX-19609. 

```bash
$ bin/infractl-darwin-arm64 create gke-default this-name-is-way-too-loooooooooooooooooooooooooooooooooooooooong
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
Error: cluster name too long
$ bin/infractl-darwin-arm64 create gke-default t                                        
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
Error: cluster name too short
$ bin/infractl-darwin-arm64 create gke-default tFAISOFJAfsoi
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
Error: The name does not match the requirements. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.
```