### PR TITLE
Allow PRs to pull images

### DIFF
--- a/chart/infra-server/templates/deployment.yaml
+++ b/chart/infra-server/templates/deployment.yaml
@@ -55,3 +55,9 @@ spec:
         - name: configuration
           secret:
             secretName: infra-server-secrets
+
+{{ if eq .Values.deployment "local" }}
+
+      imagePullSecrets:
+        - name: infra-image-registry-pull-secret
+{{ end }}

--- a/chart/infra-server/templates/deployment.yaml
+++ b/chart/infra-server/templates/deployment.yaml
@@ -59,5 +59,5 @@ spec:
 {{ if eq .Values.deployment "local" }}
 
       imagePullSecrets:
-        - name: infra-image-registry-pull-secret-2
+        - name: infra-image-registry-pull-secret
 {{ end }}

--- a/chart/infra-server/templates/deployment.yaml
+++ b/chart/infra-server/templates/deployment.yaml
@@ -59,5 +59,5 @@ spec:
 {{ if eq .Values.deployment "local" }}
 
       imagePullSecrets:
-        - name: infra-image-registry-pull-secret
+        - name: infra-image-registry-pull-secret-2
 {{ end }}

--- a/chart/infra-server/templates/secrets.yaml
+++ b/chart/infra-server/templates/secrets.yaml
@@ -88,7 +88,7 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 
 metadata:
-  name: infra-image-registry-pull-secret-2
+  name: infra-image-registry-pull-secret
   namespace: infra
 
 data:

--- a/chart/infra-server/templates/secrets.yaml
+++ b/chart/infra-server/templates/secrets.yaml
@@ -79,3 +79,19 @@ data:
     {{- .Files.Get "static/test-connect-artifact.yaml" | b64enc | nindent 4 }}
 
 {{ end }}
+
+{{ if eq .Values.deployment "local" }}
+---
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+
+metadata:
+  name: infra-image-registry-pull-secret
+  namespace: infra
+
+data:
+  .dockerconfigjson: {{ .Values.pullSecrets.stackroxInfraGCR }}
+
+{{ end }}

--- a/chart/infra-server/templates/secrets.yaml
+++ b/chart/infra-server/templates/secrets.yaml
@@ -88,7 +88,7 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 
 metadata:
-  name: infra-image-registry-pull-secret
+  name: infra-image-registry-pull-secret-2
   namespace: infra
 
 data:


### PR DESCRIPTION
Infra PR GKE clusters run in RH GCP and need a pull secret to pull images from SR GCR.

Ultimately these images need to be pushed elsewhere: https://issues.redhat.com/browse/ROX-19827

Requires: https://github.com/stackrox/automation-iac/pull/16