### PR TITLE
Revert "ROX-19609: add cluster name validation to infractl (#980)"

### DIFF
--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -118,12 +118,7 @@ func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, args []
 	displayUserNotes(cmd, args, &req)
 
 	if len(args) > 1 {
-		name := args[1]
-		err := validateName(name)
-		if err != nil {
-			return nil, err
-		}
-		req.Parameters["name"] = name
+		req.Parameters["name"] = args[1]
 	} else {
 		name, err := determineName(ctx, conn, args[0])
 		if err != nil {
@@ -149,25 +144,6 @@ func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, args []
 	}
 
 	return prettyResourceByID(*clusterID), nil
-}
-
-func validateName(name string) error {
-	if len(name) < 3 {
-		return errors.New("cluster name too short")
-	}
-	if len(name) > 28 {
-		return errors.New("cluster name too long")
-	}
-
-	match, err := regexp.MatchString(`^(?:[a-z](?:[-a-z0-9]{0,28}[a-z0-9])?)$`, name)
-	if err != nil {
-		return err
-	}
-	if !match {
-		return errors.New("The name does not match the requirements. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.")
-	}
-
-	return nil
 }
 
 func determineWorkingEnvironment() {

--- a/cmd/infractl/cluster/create/create.bats
+++ b/cmd/infractl/cluster/create/create.bats
@@ -123,24 +123,6 @@ setup() {
   assert_output --partial "parameter \"main-image\" was not provided"
 }
 
-@test "provided name failed validation because too short" {
-  run infractl create test-qa-demo ab
-  assert_failure
-  assert_output --partial "Error: cluster name too short"
-}
-
-@test "provided name failed validation because too long" {
-  run infractl create test-qa-demo this-name-will-be-too-loooooooooooooooooooong
-  assert_failure
-  assert_output --partial "Error: cluster name too long"
-}
-
-@test "provided name failed validation because does not match regex" {
-  run infractl create test-qa-demo THIS-IN-INVALID
-  assert_failure
-  assert_output --partial "Error: The name does not match the requirements."
-}
-
 infractl() {
   "$ROOT"/bin/infractl -e localhost:8443 -k "$@"
 }


### PR DESCRIPTION
This reverts commit 5128fa5b35755f96f782a6629851e5dd1e37c3cb.