### PR TITLE
ROX-17295: trusted certificates for openshift-4

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -302,6 +302,11 @@
       value: false
       kind: optional
 
+    - name: trusted-certs-enabled
+      description: Should trusted certificates be created
+      value: false
+      kind: optional
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -406,6 +411,11 @@
         Version string of the central-db container image tag to use. Setting this value will enable central-db.
         Default will be derived from the Helm chart.
 
+    - name: trusted-certs-enabled
+      description: Should trusted certificates be created
+      value: false
+      kind: optional
+
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -491,6 +501,11 @@
 
     - name: fips-enabled
       description: should fips be enabled
+      value: false
+      kind: optional
+
+    - name: trusted-certs-enabled
+      description: Should trusted certificates be created
       value: false
       kind: optional
 

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -17,6 +17,7 @@ spec:
       - name: central-db-image-tag
       - name: central-services-helm-chart-version
       - name: secured-cluster-services-helm-chart-version
+      - name: trusted-certs-enabled
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -75,7 +76,7 @@ spec:
 
     - name: create
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.11
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         volumeMounts:
           - name: data
@@ -110,6 +111,8 @@ spec:
             value: "e2-standard-16"
           - name: REGION
             value: "us-east1"
+          - name: TRUSTED_CERTS_ENABLED
+            value: "{{workflow.parameters.trusted-certs-enabled}}"
 
     - name: pre-install
       script:
@@ -235,7 +238,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.11
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -76,7 +76,7 @@ spec:
 
     - name: create
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         volumeMounts:
           - name: data
@@ -238,7 +238,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -22,6 +22,7 @@ spec:
       - name: pull-secret
         value: ""
       - name: fips-enabled
+      - name: trusted-certs-enabled
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -75,7 +76,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.8
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -111,6 +112,8 @@ spec:
             value: "{{workflow.parameters.region}}"
           - name: FIPS_ENABLED
             value: "{{workflow.parameters.fips-enabled}}"
+          - name: TRUSTED_CERTS_ENABLED
+            value: "{{workflow.parameters.trusted-certs-enabled}}"
         volumeMounts:
           - name: data
             mountPath: /data
@@ -120,7 +123,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.8
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -76,7 +76,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -123,7 +123,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -22,6 +22,7 @@ spec:
       - name: pull-secret
         value: ""
       - name: fips-enabled
+      - name: trusted-certs-enabled
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -75,7 +76,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.8
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -111,6 +112,8 @@ spec:
             value: "{{workflow.parameters.region}}"
           - name: FIPS_ENABLED
             value: "{{workflow.parameters.fips-enabled}}"
+          - name: TRUSTED_CERTS_ENABLED
+            value: "{{workflow.parameters.trusted-certs-enabled}}"
         volumeMounts:
           - name: data
             mountPath: /data
@@ -120,7 +123,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.6.8
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -76,7 +76,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -123,7 +123,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.0-1-gd92b417d7f-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
         imagePullPolicy: Always
         command:
           - entrypoint.sh


### PR DESCRIPTION
See https://github.com/stackrox/automation-flavors/pull/152.

I tested both ingress and api certificates successfully on a dev cluster I created with the new infra version.

The certificate creation is behind a feature flag (`trusted-certs-enabled`) with default false. If we don't observe any issues, we may switch the default to true later on.

<img width="1523" alt="Screenshot 2023-09-27 at 15 02 34" src="https://github.com/stackrox/infra/assets/55607356/d4d99944-9b7d-430d-974b-b9c22b84afe3">