### PR TITLE
Use more consistent artifact naming for openshift clusters

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -306,6 +306,7 @@
     - name: kubeconfig
       description: Kube config for connecting to this cluster
 
+    # (deprecated by cluster-console-password)
     - name: kubeadmin-password
       description: The kubeadmin user password for the openshift console
 
@@ -321,6 +322,15 @@
 
     - name: dotenv
       description: Environment variables used to access the cluster and consoles
+
+    - name: cluster-console-url
+      description: The URL for the openshift console
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
 
 ######################
 #  openshift-4-demo  #
@@ -429,6 +439,15 @@
     - name: dotenv
       description: Environment variables used to access the cluster and consoles
 
+    - name: cluster-console-url
+      description: The URL for the openshift console
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
+
 ############################
 #  openshift-4-perf-scale  #
 ############################
@@ -498,6 +517,7 @@
     - name: kubeconfig
       description: Kube config for connecting to this cluster
 
+    # (deprecated by cluster-console-password)
     - name: kubeadmin-password
       description: The kubeadmin user password for the openshift console
 
@@ -513,6 +533,15 @@
 
     - name: dotenv
       description: Environment variables used to access the cluster and consoles
+
+    - name: cluster-console-url
+      description: The URL for the openshift console
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
 
 #####################
 #  AWS EKS          #
@@ -635,6 +664,15 @@
 
     - name: data
       description: An archive that includes ssh keys to connect to cluster nodes
+
+    - name: cluster-console-url
+      description: The URL for the openshift console
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
 
 #####################
 #  Openshift ROSA   #

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -707,6 +707,15 @@
     - name: data
       description: An archive that includes ssh keys to connect to cluster nodes
 
+    - name: cluster-console-url
+      description: The URL for the openshift console
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
+
 #########################
 #  Openshift OSD on AWS #
 #########################

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -667,6 +667,7 @@
 
     - name: cluster-console-url
       description: The URL for the openshift console
+      tags: [url]
 
     - name: cluster-console-username
       description: The username to login at the openshift console
@@ -709,6 +710,7 @@
 
     - name: cluster-console-url
       description: The URL for the openshift console
+      tags: [url]
 
     - name: cluster-console-username
       description: The username to login at the openshift console
@@ -749,6 +751,16 @@
     - name: data
       description: An archive that includes ssh keys to connect to cluster nodes
 
+    - name: cluster-console-url
+      description: The URL for the openshift console
+      tags: [url]
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
+
 #########################
 #  Openshift OSD on GCP #
 #########################
@@ -781,6 +793,16 @@
 
     - name: data
       description: An archive that includes ssh keys to connect to cluster nodes
+
+    - name: cluster-console-url
+      description: The URL for the openshift console
+      tags: [url]
+
+    - name: cluster-console-username
+      description: The username to login at the openshift console
+
+    - name: cluster-console-password
+      description: The password to login at the openshift console
 
 {{ if ne .Values.deployment "production" -}}
 #################

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -192,10 +192,15 @@ spec:
             mountPath: /data
 
     - name: gather
-      container:
+      script:
         image: busybox
-        imagePullPolicy: Always
-        command: [echo, "gathering artifacts"]
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${OPENSHIFT_CONSOLE_URL}" > cluster-console-url
+          echo "${OPENSHIFT_CONSOLE_USERNAME}" > cluster-console-username
+          echo "${OPENSHIFT_CONSOLE_PASSWORD}" > cluster-console-password
         volumeMounts:
           - name: data
             mountPath: /data
@@ -229,6 +234,18 @@ spec:
             path: /data
             archive:
               tar: {}
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -41,6 +41,9 @@ spec:
         - - name: create
             template: create
 
+        - - name: gather
+            template: gather
+
         - - name: wait
             template: wait
 
@@ -114,6 +117,34 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /data
+
+    - name: gather
+      script:
+        image: busybox
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${OPENSHIFT_CONSOLE_URL}" > cluster-console-url
+          echo "${OPENSHIFT_CONSOLE_USERNAME}" > cluster-console-username
+          echo "${OPENSHIFT_CONSOLE_PASSWORD}" > cluster-console-password
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      outputs:
+        artifacts:
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -115,6 +115,34 @@ spec:
           - name: data
             mountPath: /data
 
+    - name: gather more
+      script:
+        image: busybox
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${OPENSHIFT_CONSOLE_URL}" > cluster-console-url
+          echo "${OPENSHIFT_CONSOLE_USERNAME}" > cluster-console-username
+          echo "${OPENSHIFT_CONSOLE_PASSWORD}" > cluster-console-password
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      outputs:
+        artifacts:
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
+
     - name: wait
       suspend: {}
 

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -41,6 +41,9 @@ spec:
         - - name: create
             template: create
 
+        - - name: gather
+            template: gather
+
         - - name: wait
             template: wait
 
@@ -115,7 +118,7 @@ spec:
           - name: data
             mountPath: /data
 
-    - name: gather more
+    - name: gather
       script:
         image: busybox
         command: [sh]

--- a/chart/infra-server/static/workflow-openshift-aro.yaml
+++ b/chart/infra-server/static/workflow-openshift-aro.yaml
@@ -82,10 +82,15 @@ spec:
             mountPath: /data
 
     - name: gather
-      container:
+      script:
         image: busybox
-        imagePullPolicy: Always
-        command: [echo, "gathering artifacts"]
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${CONSOLE_ENDPOINT}" > cluster-console-url
+          echo "${CONSOLE_USER}" > cluster-console-username
+          echo "${CONSOLE_PASSWORD}" > cluster-console-password
         volumeMounts:
           - name: data
             mountPath: /data
@@ -103,6 +108,18 @@ spec:
             path: /data
             archive:
               tar: {}
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-openshift-aro.yaml
+++ b/chart/infra-server/static/workflow-openshift-aro.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-aro:0.2.16
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-aro-0.2.16
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -127,7 +127,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-aro:0.2.16
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-aro-0.2.16
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-rosa.yaml
+++ b/chart/infra-server/static/workflow-openshift-rosa.yaml
@@ -77,10 +77,15 @@ spec:
             mountPath: /data
 
     - name: gather
-      container:
+      script:
         image: busybox
-        imagePullPolicy: Always
-        command: [echo, "gathering artifacts"]
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${CONSOLE_ENDPOINT}" > cluster-console-url
+          echo "${CONSOLE_USER}" > cluster-console-username
+          echo "${CONSOLE_PASSWORD}" > cluster-console-password
         volumeMounts:
           - name: data
             mountPath: /data
@@ -98,6 +103,18 @@ spec:
             path: /data
             archive:
               tar: {}
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-osd-aws.yaml
+++ b/chart/infra-server/static/workflow-osd-aws.yaml
@@ -78,10 +78,15 @@ spec:
             mountPath: /data
 
     - name: gather
-      container:
+      script:
         image: busybox
-        imagePullPolicy: Always
-        command: [echo, "gathering artifacts"]
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${CLUSTER_CONSOLE_ENDPOINT}" > cluster-console-url
+          echo "${CLUSTER_USERNAME}" > cluster-console-username
+          echo "${CLUSTER_PASSWORD}" > cluster-console-password
         volumeMounts:
           - name: data
             mountPath: /data
@@ -99,6 +104,18 @@ spec:
             path: /data
             archive:
               tar: {}
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -75,10 +75,15 @@ spec:
             mountPath: /data
 
     - name: gather
-      container:
+      script:
         image: busybox
-        imagePullPolicy: Always
-        command: [echo, "gathering artifacts"]
+        command: [sh]
+        source: |
+          cd /data
+          . ./dotenv
+          echo "${CLUSTER_CONSOLE_ENDPOINT}" > cluster-console-url
+          echo "${CLUSTER_USERNAME}" > cluster-console-username
+          echo "${CLUSTER_PASSWORD}" > cluster-console-password
         volumeMounts:
           - name: data
             mountPath: /data
@@ -96,6 +101,18 @@ spec:
             path: /data
             archive:
               tar: {}
+          - name: cluster-console-url
+            path: /data/cluster-console-url
+            archive:
+              none: {}
+          - name: cluster-console-username
+            path: /data/cluster-console-username
+            archive:
+              none: {}
+          - name: cluster-console-password
+            path: /data/cluster-console-password
+            archive:
+              none: {}
 
     - name: wait
       suspend: {}


### PR DESCRIPTION
It is somewhat annoying that these cluster flavors do not all expose the console connection parameters in artifacts. This PR makes them all consistently provide artifacts named:

- cluster-console-url
- cluster-console-username
- cluster-console-password

Existing other names are kept for any automation that depends on them e.g. kubeadmin-password. The change is relatively similar across flavors as all OCP 4 flavors create a `dotenv` artifact but they differ in the env name for the three values.

## Testing

- [x] openshift-4
- [x] openshift-4-demo
- [x] openshift-4-perf-scale
- [x] aro
- [x] rosa
- [x] osd-aws
- [x] osd-gcp

