### PR TITLE
fix: cluster name length should be maximum 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+- Fix: CLI and UI now consistently enforce restrictions on the cluster name format and length
+
 ## [0.8.0]
 
 - Switch GKE based flavors (gke-default, demo, qa-demo) to use a RH project (ROX-17123,ROX-19217)

--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -264,6 +264,9 @@ func getNameForQaDemoFlavor() string {
 	name := strings.TrimSuffix(workingEnvironment.tag, "-dirty")
 	name = strings.ReplaceAll(name, ".", "-")
 
+	// Ensure that the name is a maximum of 27 characters long.
+	name = name[:27]
+
 	return name
 }
 

--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -155,11 +155,11 @@ func validateName(name string) error {
 	if len(name) < 3 {
 		return errors.New("cluster name too short")
 	}
-	if len(name) > 27 {
+	if len(name) > 28 {
 		return errors.New("cluster name too long")
 	}
 
-	match, err := regexp.MatchString(`^(?:[a-z](?:[-a-z0-9]{1,25}[a-z0-9]))$`, name)
+	match, err := regexp.MatchString(`^(?:[a-z](?:[-a-z0-9]{1,26}[a-z0-9]))$`, name)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func validateName(name string) error {
 		return errors.New(
 			"The name does not match the requirements. " +
 				"Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number. " +
-				"A minimum length of 3 characters and a maximum length of 27 is allowed.")
+				"A minimum length of 3 characters and a maximum length of 28 is allowed.")
 	}
 
 	return nil
@@ -264,9 +264,9 @@ func getNameForQaDemoFlavor() string {
 	name := strings.TrimSuffix(workingEnvironment.tag, "-dirty")
 	name = strings.ReplaceAll(name, ".", "-")
 
-	// Ensure that the generated name is a maximum of 27 characters long and does not end with hyphen.
-	if len(name) > 27 {
-		name = name[:27]
+	// Ensure that the generated name is a maximum of 28 characters long and does not end with hyphen.
+	if len(name) > 28 {
+		name = name[:28]
 		name = strings.TrimSuffix(name, "-")
 	}
 

--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -155,16 +155,19 @@ func validateName(name string) error {
 	if len(name) < 3 {
 		return errors.New("cluster name too short")
 	}
-	if len(name) > 28 {
+	if len(name) > 27 {
 		return errors.New("cluster name too long")
 	}
 
-	match, err := regexp.MatchString(`^(?:[a-z](?:[-a-z0-9]{0,28}[a-z0-9])?)$`, name)
+	match, err := regexp.MatchString(`^(?:[a-z](?:[-a-z0-9]{1,25}[a-z0-9]))$`, name)
 	if err != nil {
 		return err
 	}
 	if !match {
-		return errors.New("The name does not match the requirements. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.")
+		return errors.New(
+			"The name does not match the requirements. " +
+				"Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number. " +
+				"A minimum length of 3 characters and a maximum length of 27 is allowed.")
 	}
 
 	return nil

--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -264,9 +264,10 @@ func getNameForQaDemoFlavor() string {
 	name := strings.TrimSuffix(workingEnvironment.tag, "-dirty")
 	name = strings.ReplaceAll(name, ".", "-")
 
-	// Ensure that the generated name is a maximum of 27 characters long.
+	// Ensure that the generated name is a maximum of 27 characters long and does not end with hyphen.
 	if len(name) > 27 {
 		name = name[:27]
+		name = strings.TrimSuffix(name, "-")
 	}
 
 	return name

--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -264,8 +264,10 @@ func getNameForQaDemoFlavor() string {
 	name := strings.TrimSuffix(workingEnvironment.tag, "-dirty")
 	name = strings.ReplaceAll(name, ".", "-")
 
-	// Ensure that the name is a maximum of 27 characters long.
-	name = name[:27]
+	// Ensure that the generated name is a maximum of 27 characters long.
+	if len(name) > 27 {
+		name = name[:27]
+	}
 
 	return name
 }

--- a/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
+++ b/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
@@ -28,7 +28,7 @@ const clusterService = new ClusterServiceApi(configuration);
 function helpByParameterName(name?: string): string {
   const help: { [key: string]: string } = {
     name:
-      "You can use the generated name, or type in your own. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number. The name must be between 3 and 27 characters long.",
+      "You can use the generated name, or type in your own. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number. The name must be between 3 and 28 characters long.",
   };
 
   if (name && name in help) {
@@ -42,9 +42,9 @@ const schemasByParameterName: { [key: string]: yup.BaseSchema } = {
   name: yup
     .string()
     .min(3, 'Too short')
-    .max(27, 'Too long')
+    .max(28, 'Too long')
     .matches(
-      /^(?:[a-z](?:[a-z0-9-]{1,25}[a-z0-9]))$/,
+      /^(?:[a-z](?:[a-z0-9-]{1,26}[a-z0-9]))$/,
       'The input value does not match its requirements. See the (?) section for details.'
     ),
   nodes: yup

--- a/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
+++ b/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
@@ -38,12 +38,13 @@ function helpByParameterName(name?: string): string {
 }
 
 const schemasByParameterName: { [key: string]: yup.BaseSchema } = {
+  // name length is restricted by certificate generation
   name: yup
     .string()
     .min(3, 'Too short')
     .max(27, 'Too long')
     .matches(
-      /^(?:[a-z](?:[-a-z0-9]{1,25}[a-z0-9]))$/, // this is what GKE expects
+      /^(?:[a-z](?:[a-z0-9-]{1,25}[a-z0-9]))$/,
       'The input value does not match its requirements. See the (?) section for details.'
     ),
   nodes: yup

--- a/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
+++ b/ui/src/containers/LaunchClusterPage/ClusterForm.tsx
@@ -28,7 +28,7 @@ const clusterService = new ClusterServiceApi(configuration);
 function helpByParameterName(name?: string): string {
   const help: { [key: string]: string } = {
     name:
-      "You can use the generated name, or type in your own. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number.",
+      "You can use the generated name, or type in your own. Only lowercase letters, numbers, and '-' allowed, must start with a letter and end with a letter or number. The name must be between 3 and 27 characters long.",
   };
 
   if (name && name in help) {
@@ -41,9 +41,9 @@ const schemasByParameterName: { [key: string]: yup.BaseSchema } = {
   name: yup
     .string()
     .min(3, 'Too short')
-    .max(28, 'Too long')
+    .max(27, 'Too long')
     .matches(
-      /^(?:[a-z](?:[-a-z0-9]{0,38}[a-z0-9])?)$/, // this is what GKE expects
+      /^(?:[a-z](?:[-a-z0-9]{1,25}[a-z0-9]))$/, // this is what GKE expects
       'The input value does not match its requirements. See the (?) section for details.'
     ),
   nodes: yup

--- a/ui/src/utils/cluster.utils.ts
+++ b/ui/src/utils/cluster.utils.ts
@@ -19,10 +19,9 @@ export function generateClusterName(username = ''): string {
   // prepare to combine, but filter any empty part (only one that should ever be empty is user string)
   const nameArray = [userPart, datePart, randomPart].filter(Boolean);
 
-  // combine the 3 parts, truncate it at 28 characters, and remove a trailing '-', if any.
-  // Truncation is needed to allow generating wildcard certificates for OpenShift using Let's Encrypt: since LE insists
-  // on the domain forming the Common Name of the certificate, the string '*.apps.<name>.openshift.infra.rox.systems'
-  // must not exceed 64 characters. This leaves a budget of 29 characters for the <name> portion.
-  // RS-171 - 29 chars raises openshift error: "openshift_public_hostname must be 63 characters or less"
-  return nameArray.join('-').slice(0, 28).replace(/-$/, '');
+  // ROX-15492
+  //   - OCP 3.11 allows us a maximum of up to 27 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
+  //   - OCP 4 demo: Let's Encrypt allows common names of up to 63 characters. With the format '*.apps.<name>.openshift.infra.rox.systems', 27 characters remain for the name.
+  // Combine the 3 parts, truncate it at 27 characters, and remove a trailing '-', if any.
+  return nameArray.join('-').slice(0, 27).replace(/-$/, '');
 }

--- a/ui/src/utils/cluster.utils.ts
+++ b/ui/src/utils/cluster.utils.ts
@@ -20,8 +20,8 @@ export function generateClusterName(username = ''): string {
   const nameArray = [userPart, datePart, randomPart].filter(Boolean);
 
   // ROX-15492
-  //   - OCP 3.11 flavor allows us a maximum of up to 27 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
+  //   - OCP 3.11 flavor allows us a maximum of up to 28 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
   //   - OCP 4 demo: Let's Encrypt allows common names of up to 63 characters. With the format '*.apps.<name>.openshift.infra.rox.systems', 28 characters remain for the name.
-  // Combine the 3 parts, truncate it at 27 characters, and remove a trailing '-', if any.
-  return nameArray.join('-').slice(0, 27).replace(/-$/, '');
+  // Combine the 3 parts, truncate it at 28 characters, and remove a trailing '-', if any.
+  return nameArray.join('-').slice(0, 28).replace(/-$/, '');
 }

--- a/ui/src/utils/cluster.utils.ts
+++ b/ui/src/utils/cluster.utils.ts
@@ -20,8 +20,8 @@ export function generateClusterName(username = ''): string {
   const nameArray = [userPart, datePart, randomPart].filter(Boolean);
 
   // ROX-15492
-  //   - OCP 3.11 allows us a maximum of up to 27 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
-  //   - OCP 4 demo: Let's Encrypt allows common names of up to 63 characters. With the format '*.apps.<name>.openshift.infra.rox.systems', 27 characters remain for the name.
+  //   - OCP 3.11 flavor allows us a maximum of up to 27 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
+  //   - OCP 4 demo: Let's Encrypt allows common names of up to 63 characters. With the format '*.apps.<name>.openshift.infra.rox.systems', 28 characters remain for the name.
   // Combine the 3 parts, truncate it at 27 characters, and remove a trailing '-', if any.
   return nameArray.join('-').slice(0, 27).replace(/-$/, '');
 }


### PR DESCRIPTION
# Root cause analysis and fixes
## OCP 3.11:
- Bug: https://issues.redhat.com/browse/ROX-15492 
- Fixed long time ago in https://github.com/stackrox/automation-flavors/pull/71 
- Validation “name” in OCP 3.11 flavor: https://github.com/stackrox/automation-flavors/blob/master/openshift/multi/terraform/main.tf#L43 
- Maximum allowed: 28 characters (<=28) to stay within 63 character limit for “openshift_public_hostname”
Question: Does this also affect other OCP versions?

## UI specifies:
- Input validation: https://github.com/stackrox/infra/blob/master/ui/src/containers/LaunchClusterPage/ClusterForm.tsx#L41-L48 
  - Maximum length of 28 characters (<= 28, [Code](https://github.com/stackrox/infra/blob/master/ui/src/containers/LaunchClusterPage/ClusterForm.tsx#L44C12-L44C12))
  - THAT SHOULD BE 27 characters (<= 28), because max is inclusive
  - Regex allows 40 characters (<= 40, [Code](https://github.com/stackrox/infra/blame/master/ui/src/containers/LaunchClusterPage/ClusterForm.tsx#L45-L46))
  - IIUC that is the limit for GKE cluster names
  - NEW REGEX: `/^(?:[a-z](?:[-a-z0-9]{0,26}[a-z0-9])?)$/`
  - SIMPLIFIED REGEX `/^(?:[a-z](?:[-a-z0-9]{1,25}[a-z0-9]))$/`
    - Enforces both pattern and length restrictions
- Auto-generated names: https://github.com/stackrox/infra/blame/d04b091a5df755694a466aac6f160a2c193ad2f5/ui/src/utils/cluster.utils.ts#L22-L25 
  - Name cropping implemented in https://github.com/stackrox/infra/pull/639 
  - .slice(0, 28) is correct 
  - Comment should be updated to say that this is not just an OCP 3.11 requirement, but also Let's Encrypt. 

## CLI specifies:
- Input validation: https://github.com/stackrox/infra/blob/master/cmd/infractl/cluster/create/command.go#L154-L171. That should be updated according to what is written above.
- Generated names: They may be too long, example: init-40-20-x-1000-g4f371fc1cc (1000th commit after 40.20.x tag, 29 characters, unlikely, but still should be considered). Also here, cropping after 28 chars (and trim any hyphens)