### PR TITLE
Use public image for OSD-on-GCP flavor

### DIFF
--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -38,7 +38,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.24
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.2.24
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -120,7 +120,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: gcr.io/stackrox-infra/automation-flavors/openshift-osd:0.2.24
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.2.24
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh


### PR DESCRIPTION
This change was tested with #1014 but missed that PR/commit.