### PR TITLE
ROX-19218, etc: Move GCP based OCP flavors in infra to a RH project

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -495,7 +495,7 @@
 
     - name: master-node-type
       description: the type of master nodes
-      value: c2d-highcpu-16
+      value: n1-standard-16
       kind: optional
 
     - name: master-node-count
@@ -505,7 +505,7 @@
 
     - name: worker-node-type
       description: the type of worker nodes
-      value: c2d-highcpu-8
+      value: n1-standard-8
       kind: optional
 
     - name: worker-node-count

--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -55,7 +55,7 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - srox-temp-dev-test
+          - acs-team-temp-dev
         env:
           - name: AZURE_SP_USERNAME
             valueFrom:
@@ -103,7 +103,7 @@ spec:
         args:
           - destroy
           - "{{workflow.parameters.name}}"
-          - srox-temp-dev-test
+          - acs-team-temp-dev
         env:
           - name: AZURE_SP_USERNAME
             valueFrom:

--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -55,7 +55,7 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - acs-team-temp-dev
+          - srox-temp-dev-test
         env:
           - name: AZURE_SP_USERNAME
             valueFrom:
@@ -103,7 +103,7 @@ spec:
         args:
           - destroy
           - "{{workflow.parameters.name}}"
-          - acs-team-temp-dev
+          - srox-temp-dev-test
         env:
           - name: AZURE_SP_USERNAME
             valueFrom:

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -76,7 +76,7 @@ spec:
 
     - name: create
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         volumeMounts:
           - name: data
@@ -86,7 +86,6 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - acs-team-temp-dev
           - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
@@ -94,6 +93,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
           - name: PULL_SECRET
             valueFrom:
               secretKeyRef:
@@ -255,7 +256,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -267,6 +268,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -29,7 +29,7 @@ spec:
   volumes:
     - name: credentials
       secret:
-        secretName: google-credentials-openshift-4
+        secretName: openshift-4-gcp-service-account
     - name: demo-secrets
       secret:
         secretName: demo-secrets
@@ -86,13 +86,13 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - srox-temp-dev-test
-          - openshift.infra.rox.systems
+          - acs-team-temp-dev
+          - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
           - name: PULL_SECRET
             valueFrom:
@@ -124,7 +124,7 @@ spec:
         source: |
           openssl rand -base64 32 | tr "+/" "_#"  | cut -c 1-20 > /data/admin_password
           base64 /data/auth/kubeconfig | tr -d "\n" > /data/auth/kubeconfig_base64
-          subdomain="apps.{{workflow.parameters.name}}.openshift.infra.rox.systems"
+          subdomain="apps.{{workflow.parameters.name}}.ocp.infra.rox.systems"
           echo "https://console-openshift-console.${subdomain}" > /data/url-openshift
           echo "https://central-stackrox.${subdomain}" > /data/url-stackrox
       outputs:
@@ -166,7 +166,7 @@ spec:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
           - name: CENTRAL_PORT
             value: "443"
@@ -265,7 +265,7 @@ spec:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
         volumeMounts:
           - name: data

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -79,14 +79,13 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - acs-team-temp-dev
           - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
@@ -94,6 +93,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
           - name: PULL_SECRET
             valueFrom:
               secretKeyRef:
@@ -154,7 +155,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -166,6 +167,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -34,7 +34,7 @@ spec:
   volumes:
     - name: credentials
       secret:
-        secretName: google-credentials-openshift-4
+        secretName: openshift-4-gcp-service-account
 
   templates:
     - name: start
@@ -86,13 +86,13 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - srox-temp-dev-test
-          - openshift.infra.rox.systems
+          - acs-team-temp-dev
+          - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
           - name: PULL_SECRET
             valueFrom:
@@ -164,7 +164,7 @@ spec:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
         volumeMounts:
           - name: data

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -79,14 +79,13 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - acs-team-temp-dev
           - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
@@ -94,6 +93,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
           - name: PULL_SECRET
             valueFrom:
               secretKeyRef:
@@ -154,7 +155,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.1-4-g85c5c37504-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -166,6 +167,8 @@ spec:
               secretKeyRef:
                 name: openshift-4-gcp-service-account
                 key: google-credentials.json
+          - name: GCP_PROJECT
+            value : "acs-team-temp-dev"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -34,7 +34,7 @@ spec:
   volumes:
     - name: credentials
       secret:
-        secretName: google-credentials-openshift-4
+        secretName: openshift-4-gcp-service-account
 
   templates:
     - name: start
@@ -86,13 +86,13 @@ spec:
         args:
           - create
           - "{{workflow.parameters.name}}"
-          - srox-temp-dev-test
-          - openshift.infra.rox.systems
+          - acs-team-temp-dev
+          - ocp.infra.rox.systems
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
           - name: PULL_SECRET
             valueFrom:
@@ -164,7 +164,7 @@ spec:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift-4
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
         volumeMounts:
           - name: data

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -61,9 +61,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: osd-access-secrets
-                key: GCP_SA_CREDS_JSON_BASE64
+                key: GCP_SERVICE_ACCOUNT_KEY_BASE64
           - name: GCP_PROJECT
-            value: "srox-temp-dev-test"
+            value: "acs-team-temp-dev"
           - name: NODE_COUNT
             value: "{{workflow.parameters.nodes}}"
           - name: INSTANCE_TYPE
@@ -143,9 +143,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: osd-access-secrets
-                key: GCP_SA_CREDS_JSON_BASE64
+                key: GCP_SERVICE_ACCOUNT_KEY_BASE64
           - name: GCP_PROJECT
-            value: "srox-temp-dev-test"
+            value: "acs-team-temp-dev"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/templates/openshift-4/secrets.yaml
+++ b/chart/infra-server/templates/openshift-4/secrets.yaml
@@ -3,6 +3,25 @@ kind: Secret
 type: Opaque
 
 metadata:
+  name: openshift-4-gcp-service-account
+  namespace: default
+
+data:
+  google-credentials.json: |-
+    {{ required ".Values.openshift_4__gcp_service_account_key_json is undefined" .Values.openshift_4__gcp_service_account_key_json }}
+
+
+---
+
+# (deprecated) this secret is used for openshift-4 provisioning with
+# stackrox.com GCP and can be removed once the migration away from that account
+# and its projects are complete. In the meantime this must remain to facilitate
+# drain and rollback if required.
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
   name: google-credentials-openshift-4
   namespace: default
 

--- a/chart/infra-server/templates/osd/secrets.yaml
+++ b/chart/infra-server/templates/osd/secrets.yaml
@@ -14,5 +14,8 @@ data:
     {{ .Values.osdClusterManager.redHatPullSecretBase64 | b64enc }}
   OPENSHIFT_CLUSTER_MANAGER_API_TOKEN: |-
     {{ .Values.osdClusterManager.openshiftClusterManagerApiToken | b64enc }}
+  # (deprecated) used in stackrox.com GCP provisioning and can be removed once the migration away from that account and its projects are complete
   GCP_SA_CREDS_JSON_BASE64: |-
     {{ .Values.osdClusterManager.gcpSaCredsJsonBase64 | b64enc }}
+  GCP_SERVICE_ACCOUNT_KEY_BASE64: |-
+    {{ .Values.osdClusterManager.gcpServiceAccountKeyBase64 | b64enc }}

--- a/ui/src/utils/cluster.utils.ts
+++ b/ui/src/utils/cluster.utils.ts
@@ -21,7 +21,6 @@ export function generateClusterName(username = ''): string {
 
   // ROX-15492
   //   - OCP 3.11 flavor allows us a maximum of up to 28 characters to fulfil: "openshift_public_hostname must be 63 characters or less".
-  //   - OCP 4 demo: Let's Encrypt allows common names of up to 63 characters. With the format '*.apps.<name>.openshift.infra.rox.systems', 28 characters remain for the name.
   // Combine the 3 parts, truncate it at 28 characters, and remove a trailing '-', if any.
   return nameArray.join('-').slice(0, 28).replace(/-$/, '');
 }


### PR DESCRIPTION
Changes as described in: https://docs.google.com/document/d/1zFr2mUZVEZNofD5S1gj9ELSvwrKLnOe6aESm17D8IrI/edit?pli=1

IaC side: https://github.com/stackrox/automation-iac/pull/23

## Testing

Created & destroyed:

- [x] openshift-4
- [x] openshift-4-perf-scale
- [x] openshift-4-demo
- [x] osd-on-gcp

Installed ACS:

- [x] openshift-4
- [x] osd-on-gcp

Created with certs:

- [x] openshift-4
- [x] openshift-4-perf-scale
- [x] openshift-4-demo
  - secured cluster did not deploy due to a cert issue - will check if this is a bug in the existing setup
  - this appears to be an existing timing bug. I will retest post deployment and open a JIRA.
