### PR TITLE
fix: Argo ConfigMap and prepare 0.8.3 release

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Deploy infra to dev cluster
         run: |
-          ENVIRONMENT=development TEST_MODE=true make install-argo helm-deploy
+          ENVIRONMENT=development TEST_MODE=true make install-argo clean-argo-config helm-deploy
           sleep 10 # wait for old pods to disappear so the svc port-forward doesn't connect to them
           kubectl -n infra port-forward svc/infra-server-service 8443:8443 &
           sleep 10

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
           gcloud container clusters get-credentials infra-${{ inputs.environment }} \
             --project stackrox-infra \
             --region us-west2
-          ENVIRONMENT=${{ inputs.environment }} make install-argo helm-deploy
+          ENVIRONMENT=${{ inputs.environment }} make install-argo clean-argo-config helm-deploy
 
       - name: Notify infra channel about new version
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.8.3]
+
 - Deploying infra-server with Helm and GCP Secret Manager
 
 ## [0.8.2]

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -118,6 +118,9 @@ To install Argo workflow server, run:
 
 NOTE: This is a separate step and not a dependant chart for example to avoid too frequent Argo deployments.
 
+Also note that if you plan to deploy `infra-server` to this cluster, you will need to remove the default Argo workflow controller ConfigMap with the `clean-argo-config` Make target.
+This is required until [ROX-20269](https://issues.redhat.com/browse/ROX-20269) is resolved.
+
 ### Manual deployment
 
 To render a copy of the charts (for inspection), run:

--- a/Makefile
+++ b/Makefile
@@ -284,3 +284,4 @@ install-argo: pre-check
 .PHONY: clean-argo-config
 clean-argo-config: pre-check
 	kubectl delete configmap argo-workflows-workflow-controller-configmap -n argo || true
+	kubectl rollout restart deploy/argo-workflows-workflow-controller -n argo || true

--- a/Makefile
+++ b/Makefile
@@ -280,3 +280,7 @@ install-argo: pre-check
 		--install \
 		--create-namespace \
 		--namespace argo
+
+.PHONY: clean-argo-config
+clean-argo-config: pre-check
+	kubectl delete configmap argo-workflows-workflow-controller-configmap -n argo || true

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,8 @@ helm-template: pre-check
 .PHONY: helm-deploy
 helm-deploy: pre-check
 	@./scripts/deploy/helm.sh deploy $(VERSION) $(ENVIRONMENT) $(SECRET_VERSION)
+	# Pick up any eventual changes to the workflow controller configmap
+	@make bounce-argo-pods
 
 ## Diff
 .PHONY: helm-diff
@@ -243,6 +245,13 @@ helm-diff: pre-check
 bounce-infra-pods:
 	kubectl -n infra rollout restart deploy/infra-server-deployment
 	kubectl -n infra rollout status deploy/infra-server-deployment --watch --timeout=3m
+
+.PHONY: bounce-argo-pods
+bounce-argo-pods:
+	kubectl rollout restart deploy/argo-workflows-workflow-controller -n argo
+	kubectl rollout status deploy/argo-workflows-workflow-controller -n argo --watch --timeout=3m
+	kubectl rollout restart deploy/argo-workflows-server -n argo
+	kubectl rollout status deploy/argo-workflows-server -n argo --watch --timeout=3m
 
 #############
 ## Secrets ##
@@ -284,4 +293,3 @@ install-argo: pre-check
 .PHONY: clean-argo-config
 clean-argo-config: pre-check
 	kubectl delete configmap argo-workflows-workflow-controller-configmap -n argo || true
-	kubectl rollout restart deploy/argo-workflows-workflow-controller -n argo || true

--- a/chart/infra-server/templates/argo/secrets.yaml
+++ b/chart/infra-server/templates/argo/secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 
 metadata:
-  name: workflow-controller-configmap
+  name: argo-workflows-workflow-controller-configmap
   namespace: argo
 
 data:


### PR DESCRIPTION
The `argo-workflows-workflow-controller-configmap` ConfigMap is originally created by the Argo Helm release. It is required to configure the artefact storage. 
When attempting to install the infra-server, Helm detects that this chart does not manage the ConfigMap and fails. 
This is a workaround until https://issues.redhat.com/browse/ROX-20269 is implemented.

Tested with the PR cluster that both installs on an empty cluster and subsequent installs are working fine.

Error message after cluster provisioning would be 

```
Error (exit code 1): You need to configure artifact storage. More information on how to do this can be found in the docs: https://argoproj.github.io/argo-workflows/configure-artifact-repository/.
```