### PR TITLE
Bump demo versions to 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.8.6]
+
+- Chore: Bump demo versions to 4.2.2
+
 ## [0.8.5]
 
 - Fix: Openshift 3.11 provisioning is now based on quay.io/openshift installers (ROX-20327)

--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -7,4 +7,4 @@ home: https://github.com/stackrox/infra
 sources:
   - https://github.com/stackrox/infra
 annotations:
-  acsDemoVersion: 4.2.1
+  acsDemoVersion: 4.2.2


### PR DESCRIPTION
Bumping demo versions for ACS release 4.2.2