### PR TITLE
chore: match infra OCP credentialsMode with stackrox CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.8.7]
+
+- Add support for credentialsMode to openshift-4* flavors and default to
+  Passthrough to mimic CI.
+
 ## [0.8.6]
 
 - Chore: Bump demo versions to 4.2.2

--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,3 +8,4 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.2.2
+  ocpCredentialsMode: Passthrough

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -309,7 +309,7 @@
 
     - name: credentials-mode
       description: credentials mode
-      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      value: {{ .Chart.Annotations.ocpCredentialsMode }}
       kind: optional
       help: |
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -307,6 +307,13 @@
       value: false
       kind: optional
 
+    - name: credentials-mode
+      description: credentials mode
+      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      help: |
+        Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
+        stackrox CI.
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -426,6 +433,13 @@
       value: false
       kind: optional
 
+    - name: credentials-mode
+      description: credentials mode
+      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      help: |
+        Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
+        stackrox CI.
+
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -527,6 +541,13 @@
       description: Should trusted certificates be created
       value: false
       kind: optional
+
+    - name: credentials-mode
+      description: credentials mode
+      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      help: |
+        Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
+        stackrox CI.
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -310,6 +310,7 @@
     - name: credentials-mode
       description: credentials mode
       value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      kind: optional
       help: |
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
@@ -435,7 +436,8 @@
 
     - name: credentials-mode
       description: credentials mode
-      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      value: {{ .Chart.Annotations.ocpCredentialsMode }}
+      kind: optional
       help: |
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
@@ -544,7 +546,8 @@
 
     - name: credentials-mode
       description: credentials mode
-      value: quay.io/stackrox-io/main:{{ .Chart.Annotations.ocpCredentialsMode }}
+      value: {{ .Chart.Annotations.ocpCredentialsMode }}
+      kind: optional
       help: |
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -18,6 +18,7 @@ spec:
       - name: central-services-helm-chart-version
       - name: secured-cluster-services-helm-chart-version
       - name: trusted-certs-enabled
+      - name: credentials-mode
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -114,6 +115,8 @@ spec:
             value: "us-east1"
           - name: TRUSTED_CERTS_ENABLED
             value: "{{workflow.parameters.trusted-certs-enabled}}"
+          - name: CREDENTIALS_MODE
+            value: "{{workflow.parameters.credentials-mode}}"
 
     - name: pre-install
       script:

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -77,7 +77,7 @@ spec:
 
     - name: create
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         volumeMounts:
           - name: data
@@ -259,7 +259,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -23,6 +23,7 @@ spec:
         value: ""
       - name: fips-enabled
       - name: trusted-certs-enabled
+      - name: credentials-mode
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -118,6 +119,8 @@ spec:
             value: "{{workflow.parameters.fips-enabled}}"
           - name: TRUSTED_CERTS_ENABLED
             value: "{{workflow.parameters.trusted-certs-enabled}}"
+          - name: CREDENTIALS_MODE
+            value: "{{workflow.parameters.credentials-mode}}"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -80,7 +80,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -158,7 +158,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -80,7 +80,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.8-1-g0204b4c5e4-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -158,7 +158,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.8-1-g0204b4c5e4-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -23,6 +23,7 @@ spec:
         value: ""
       - name: fips-enabled
       - name: trusted-certs-enabled
+      - name: credentials-mode
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -118,6 +119,8 @@ spec:
             value: "{{workflow.parameters.fips-enabled}}"
           - name: TRUSTED_CERTS_ENABLED
             value: "{{workflow.parameters.trusted-certs-enabled}}"
+          - name: CREDENTIALS_MODE
+            value: "{{workflow.parameters.credentials-mode}}"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -80,7 +80,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -158,7 +158,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.2
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -80,7 +80,7 @@ spec:
             archive:
               tar: {}
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.8-1-g0204b4c5e4-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh
@@ -158,7 +158,7 @@ spec:
 
     - name: destroy
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.7
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-0.8.8-1-g0204b4c5e4-snapshot
         imagePullPolicy: Always
         command:
           - entrypoint.sh

--- a/chart/infra-server/templates/openshift-4/secrets.yaml
+++ b/chart/infra-server/templates/openshift-4/secrets.yaml
@@ -42,4 +42,4 @@ metadata:
 
 data:
   REDHAT_PULL_SECRET: |-
-    {{ required ".Values.openshift_4__redhat_pull_secret_json is undefined" .Values.openshift_4__redhat_pull_secret_json }}
+    {{ required ".Values.openshift4.redHatPullSecretBase64 is undefined" .Values.openshift4.redHatPullSecretBase64 }}

--- a/chart/infra-server/templates/openshift-4/secrets.yaml
+++ b/chart/infra-server/templates/openshift-4/secrets.yaml
@@ -42,4 +42,4 @@ metadata:
 
 data:
   REDHAT_PULL_SECRET: |-
-    {{ required ".Values.openshift4.redHatPullSecretBase64 is undefined" .Values.openshift4.redHatPullSecretBase64 }}
+    {{ required ".Values.openshift_4__redhat_pull_secret_json is undefined" .Values.openshift_4__redhat_pull_secret_json }}


### PR DESCRIPTION
stackrox/stackrox CI uses`credentialsMode: Passthrough` to reduce the number of IAM policy bindings. Infra should default to provide the same type of cluster. This PR provides a parameter to override the default.

## Testing

- [x] 2 x default (Passthrough) OCP flavors - 7 bindings should be created per cluster

```
$ INFRA_TOKEN="$STAGE_INFRA_TOKEN" bin/infractl -k -e localhost:8443 create openshift-4
ID: gj-11-08-1
```

UI defaults for openshift-4-perf-scale: https://localhost:8443/cluster/gj-11-08-spotless-scissors-b

- [x] 1 x Default OCP flavor - 21 bindings per cluster

```
$ INFRA_TOKEN="$STAGE_INFRA_TOKEN" bin/infractl -k -e localhost:8443 create openshift-4-demo --arg credentials-mode=Mint
ID: gj-11-08-3
```