### PR TITLE
chore: move openshift-multi to RH GCP

### DIFF
--- a/chart/infra-server/static/workflow-openshift-multi.yaml
+++ b/chart/infra-server/static/workflow-openshift-multi.yaml
@@ -112,11 +112,12 @@ spec:
           - "--machine-type={{inputs.parameters.machine-type}}"
           - "--install-metrics={{inputs.parameters.install-metrics}}"
           - "--install-monitoring={{inputs.parameters.install-monitoring}}"
+          - "--gcp-project=acs-team-temp-dev"
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json
 
     - name: wait
@@ -140,5 +141,5 @@ spec:
           - name: GOOGLE_CREDENTIALS
             valueFrom:
               secretKeyRef:
-                name: google-credentials-openshift
+                name: openshift-4-gcp-service-account
                 key: google-credentials.json

--- a/chart/infra-server/static/workflow-openshift-multi.yaml
+++ b/chart/infra-server/static/workflow-openshift-multi.yaml
@@ -113,6 +113,8 @@ spec:
           - "--install-metrics={{inputs.parameters.install-metrics}}"
           - "--install-monitoring={{inputs.parameters.install-monitoring}}"
           - "--gcp-project=acs-team-temp-dev"
+          - "--dns-project=acs-team-temp-dev"
+          - "--dns-zone=ocp-infra-rox-systems"
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:


### PR DESCRIPTION
[ROX-20296](https://issues.redhat.com/browse/ROX-20296), ref: https://redhat-internal.slack.com/archives/CC5UHD0KA/p1699470694025049?thread_ts=1699452056.973829&cid=CC5UHD0KA

## Testing

- [x] - create openshift-multi - check right project

```
$ INFRA_TOKEN="$STAGE_INFRA_TOKEN" bin/infractl -k -e localhost:8443 create openshift-multi
ID: gj-11-08-12
```

- [x] - destroy - ensure no leaks