### PR TITLE
fix(ROX-20938): make PWA manifest accessible without authentication

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -167,7 +167,8 @@ func serveApplicationResources(dir string, oidc auth.OidcAuth) http.Handler {
 			prefix: true,
 		},
 		{
-			path: "/manifest.json",
+			path:      "/manifest.json",
+			anonymous: true,
 		},
 		{
 			path:      "/favicon.ico",


### PR DESCRIPTION
Currently, the browser attempts to download the manifest in the background from the `BASE_URL/manifest.json`. 
It is then forwarded to `/login` and the SSO provider, which fails with 401. While a backoff seems to be implemented client-side, it is still a nuisance because it pollutes the network logs and uses unnecessary resources 🌍 🌳 . 

Example: 

![Screenshot 2023-11-20 at 14 17 42](https://github.com/stackrox/infra/assets/9576848/d5c7b55f-419b-44d6-a225-021ca1200892)


This is the manifest: https://github.com/stackrox/infra/blob/master/ui/public/manifest.json