### PR TITLE
add checksums for infractl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ cli:
 	GOARCH=amd64 GOOS=darwin ./scripts/go-build -o bin/infractl-darwin-amd64 ./cmd/infractl
 	GOARCH=arm64 GOOS=darwin ./scripts/go-build -o bin/infractl-darwin-arm64 ./cmd/infractl
 	GOARCH=amd64 GOOS=linux  ./scripts/go-build -o bin/infractl-linux-amd64  ./cmd/infractl
+	@./scripts/checksums
 
 # cli-local - Builds the infractl client binary
 # When run locally, a Darwin binary is built and installed into the user's GOPATH bin.

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+main() {
+    local filename="infractl-CHECKSUMS"
+    pushd bin/ >/dev/null || exit 1
+    rm -f "${filename}"
+    shasum -a 512 -- infractl-* > "${filename}"
+    popd bin/ >/dev/null || exit 1
+
+}
+
+main "$@"

--- a/scripts/go-build
+++ b/scripts/go-build
@@ -4,11 +4,6 @@ main() {
     # Current time in epoch seconds.
     local BUILD_TIMESTAMP="$(date +'%s')"
 
-    # The URL for the CircleCI workflow that was run for the current commit.
-    local STABLE_CIRCLECI_WORKFLOW_URL
-    if [ -n "$CIRCLE_WORKFLOW_ID" ]; then
-        STABLE_CIRCLECI_WORKFLOW_URL="https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
-    fi
 
     # The Git short SHA for the current commit.
     local STABLE_GIT_SHORT_SHA="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Add script to have checksums for infractl binaries. 
Next step is to present the file or content to the user and let them validate their download.