### PR TITLE
chore: prepare 0.8.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.8.8]
+
+- Add cluster parameters to the `infractl get <cluster-id> --json` output to help debugging.
+- Bump default demo versions to 4.3.0.
+- Add markdown for parameter help formatting.
+- Fix an issue with PWA.
+
 ## [0.8.7]
 
 - Add support for credentialsMode to openshift-4* flavors and default to


### PR DESCRIPTION
Confirmed that with a 0.8.7 the `infractl get <cluster ID> --json` command still works (it will just not output parameters, no errors - yay to protobufs!). Tested against the PR cluster.
Confirmed also that 0.8.8 CLI will show the parameters for the same cluster as expected.
