### PR TITLE
fix(CI): limit the lifespan for dependabot PR clusters

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -32,7 +32,7 @@ jobs:
           flavor: gke-default
           name: infra-pr-${{ github.event.pull_request.number }}
           args: machine-type=e2-medium,nodes=1,gcp-image-type=ubuntu_containerd
-          lifespan: 24h
+          lifespan: ${{ github.actor == 'dependabot[bot]' && '1h' || '24h' }}
           wait: true
           token: ${{ secrets.INFRA_TOKEN }}
 


### PR DESCRIPTION
Dependabot PR clusters can be short lived. Today I noticed:
```
infra-pr-1119 
infra-pr-1053 
infra-pr-1100 
infra-pr-1092 
infra-pr-1118 
infra-pr-1117 
infra-pr-1116 
infra-pr-1115 
infra-pr-1114 
infra-pr-1113 
infra-pr-1112 
infra-pr-1111 
infra-pr-1110 
infra-pr-1109 
infra-pr-1108 
infra-pr-1107 
```