### PR TITLE
ROX-15695: implement region&zone configuration for some more flavors

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -928,6 +928,13 @@
         [https://aws.amazon.com/ec2/instance-types/](https://aws.amazon.com/ec2/instance-types/) and
         [https://instances.vantage.sh/](https://instances.vantage.sh/)
 
+    - name: aws-region
+      description: AWS region to launch cluster into.
+      value: us-west-2
+      kind: optional
+      help: |
+        For whether the service is available in a region, see [List of AWS Services Available by Region](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -976,6 +983,11 @@
         custom-32-131072 custom-4-32768-ext custom-4-16384 custom-8-32768
         custom-8-16384 custom-8-65536-ext custom-16-131072-ext custom-16-32768
         custom-16-65536
+
+    - name: gcp-region
+      description: GCP Region to launch cluster into.
+      value: us-east1
+      kind: optional
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -328,7 +328,7 @@
       kind: optional
 
     - name: region
-      description: Google Cloud zone to deploy infrastructure into.
+      description: Google Cloud region to deploy infrastructure into.
       value: us-east1
       kind: optional
 
@@ -489,6 +489,11 @@
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
 
+    - name: region
+      description: Google Cloud region to deploy infrastructure into.
+      value: us-east1
+      kind: optional
+
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -589,7 +594,7 @@
       kind: optional
 
     - name: region
-      description: Google Cloud zone to deploy infrastructure into.
+      description: Google Cloud region to deploy infrastructure into.
       value: us-east1
       kind: optional
 
@@ -794,6 +799,11 @@
     - name: machine-type
       description: node machine type
       value: m5.xlarge
+      kind: optional
+
+    - name: aws-region
+      description: AWS region to deploy into.
+      value: us-east-1
       kind: optional
 
   artifacts:

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -929,7 +929,7 @@
         [https://instances.vantage.sh/](https://instances.vantage.sh/)
 
     - name: aws-region
-      description: AWS region to launch cluster into.
+      description: AWS region to launch cluster into
       value: us-west-2
       kind: optional
       help: |
@@ -985,7 +985,7 @@
         custom-16-65536
 
     - name: gcp-region
-      description: GCP Region to launch cluster into.
+      description: GCP Region to launch cluster into
       value: us-east1
       kind: optional
 

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -28,10 +28,12 @@
       kind: hardcoded
 
     - name: gcp-region
+      description: GCP region
       help: GCP region to deploy infrastructure into.
       value: us-central1
 
     - name: gcp-zone
+      description: GCP region
       help: GCP zone to deploy infrastructure into.
       value: us-central1-b
 
@@ -103,10 +105,12 @@
       help: PSPs were removed from K8s >=1.25. Enabling PSP generation on newer K8s versions will fail the deployment.
 
     - name: gcp-region
+      description: GCP region
       help: GCP region to deploy infrastructure into.
       value: us-central1
 
     - name: gcp-zone
+      description: GCP zone
       help: GCP zone to deploy infrastructure into.
       value: us-central1-b
 

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -33,7 +33,7 @@
       value: us-central1
 
     - name: gcp-zone
-      description: GCP region
+      description: GCP zone
       help: GCP zone to deploy infrastructure into.
       value: us-central1-b
 
@@ -489,11 +489,6 @@
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
 
-    - name: region
-      description: Google Cloud zone to deploy infrastructure into.
-      value: us-east1
-      kind: optional
-
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -724,8 +719,6 @@
         Specify "azure" for Azure network policy manager and "calico" for calico network policy controller.
         Defaults to "" (network policy disabled).
 
-  # TODO: add parameter for region
-
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -759,8 +752,6 @@
       description: node machine type
       value: Standard_D4s_v3
       kind: optional
-
-    # add parameter for region
 
   artifacts:
     - name: kubeconfig
@@ -804,8 +795,6 @@
       description: node machine type
       value: m5.xlarge
       kind: optional
-
-    # add parameter for region
 
   artifacts:
     - name: kubeconfig
@@ -929,8 +918,6 @@
         [https://aws.amazon.com/ec2/instance-types/](https://aws.amazon.com/ec2/instance-types/) and
         [https://instances.vantage.sh/](https://instances.vantage.sh/)
 
-    # add parameter for region
-
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -979,8 +966,6 @@
         custom-32-131072 custom-4-32768-ext custom-4-16384 custom-8-32768
         custom-8-16384 custom-8-65536-ext custom-16-131072-ext custom-16-32768
         custom-16-65536
-
-    # add parameter for region
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -27,6 +27,14 @@
       value: "false"
       kind: hardcoded
 
+    - name: gcp-region
+      help: GCP region to deploy infrastructure into.
+      value: us-central1
+
+    - name: gcp-zone
+      help: GCP zone to deploy infrastructure into.
+      value: us-central1-b
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to cluster
@@ -94,6 +102,14 @@
       kind: optional
       help: PSPs were removed from K8s >=1.25. Enabling PSP generation on newer K8s versions will fail the deployment.
 
+    - name: gcp-region
+      help: GCP region to deploy infrastructure into.
+      value: us-central1
+
+    - name: gcp-zone
+      help: GCP zone to deploy infrastructure into.
+      value: us-central1-b
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to cluster
@@ -157,7 +173,7 @@
         [node-images](https://cloud.google.com/kubernetes-engine/docs/concepts/node-images)
 
     - name: gcp-zone
-      description: The zone in GCP to delete the cluster from
+      description: Google Cloud zone to deploy infrastructure into.
       value: us-central1-a
       kind: optional
 
@@ -469,6 +485,11 @@
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
 
+    - name: region
+      description: Google Cloud zone to deploy infrastructure into.
+      value: us-east1
+      kind: optional
+
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -699,6 +720,8 @@
         Specify "azure" for Azure network policy manager and "calico" for calico network policy controller.
         Defaults to "" (network policy disabled).
 
+  # TODO: add parameter for region
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -732,6 +755,8 @@
       description: node machine type
       value: Standard_D4s_v3
       kind: optional
+
+    # add parameter for region
 
   artifacts:
     - name: kubeconfig
@@ -775,6 +800,8 @@
       description: node machine type
       value: m5.xlarge
       kind: optional
+
+    # add parameter for region
 
   artifacts:
     - name: kubeconfig
@@ -824,7 +851,7 @@
       value: "true"
       kind: optional
       help: |
-        Run as ROSA HCP? Setting this to `false` will create a 
+        Run as ROSA HCP? Setting this to `false` will create a
         ROSA Classic cluster instead of HCP/Hypershift.
 
     - name: subnet-ids
@@ -833,7 +860,7 @@
       kind: optional
       help: |
         Set like "public_subnet,private_subnet"
-        It will be placed in the command like `rosa create cluster --subnet-ids $SUBNET_IDS` 
+        It will be placed in the command like `rosa create cluster --subnet-ids $SUBNET_IDS`
         Set empty for the installer to create a new empty vpc and subnets.
 
     - name: rosa-args
@@ -898,6 +925,8 @@
         [https://aws.amazon.com/ec2/instance-types/](https://aws.amazon.com/ec2/instance-types/) and
         [https://instances.vantage.sh/](https://instances.vantage.sh/)
 
+    # add parameter for region
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -946,6 +975,8 @@
         custom-32-131072 custom-4-32768-ext custom-4-16384 custom-8-32768
         custom-8-16384 custom-8-65536-ext custom-16-131072-ext custom-16-32768
         custom-16-65536
+
+    # add parameter for region
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -18,6 +18,8 @@ spec:
       - name: central-db-image
       - name: k8s-version
       - name: enable-psps
+      - name: gcp-region
+      - name: gcp-zone
 
   volumes:
     - name: credentials
@@ -118,7 +120,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.8.0
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -132,6 +134,8 @@ spec:
           - --creation-source=infra
           - --k8s-version={{workflow.parameters.k8s-version}}
           - --enable-psps={{workflow.parameters.enable-psps}}
+          - --gcp-region={{workflow.parameters.gcp-region}}
+          - --gcp-zone={{workflow.parameters.gcp-zone}}
         volumeMounts:
           - name: credentials
             mountPath: /tmp/google-credentials.json
@@ -184,7 +188,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.8.0
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -120,7 +120,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.7
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -188,7 +188,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.7
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -120,7 +120,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -188,7 +188,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -19,6 +19,7 @@ spec:
       - name: secured-cluster-services-helm-chart-version
       - name: trusted-certs-enabled
       - name: credentials-mode
+      - name: region
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -112,7 +113,7 @@ spec:
           - name: WORKER_NODE_TYPE
             value: "e2-standard-16"
           - name: REGION
-            value: "us-east1"
+            value: "{{workflow.parameters.region}}"
           - name: TRUSTED_CERTS_ENABLED
             value: "{{workflow.parameters.trusted-certs-enabled}}"
           - name: CREDENTIALS_MODE

--- a/chart/infra-server/static/workflow-openshift-rosa.yaml
+++ b/chart/infra-server/static/workflow-openshift-rosa.yaml
@@ -11,6 +11,8 @@ spec:
         value: "4"
       - name: machine-type
         value: "m5.xlarge"
+      - name: aws-region
+        value: "us-east-1"
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -72,6 +74,8 @@ spec:
             value: "{{workflow.parameters.machine-type}}"
           - name: CREATION_SOURCE
             value: "infra"
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
         volumeMounts:
           - name: data
             mountPath: /data
@@ -150,6 +154,8 @@ spec:
               secretKeyRef:
                 name: osd-access-secrets
                 key: REDHAT_PULL_SECRET_BASE64
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-osd-aws.yaml
+++ b/chart/infra-server/static/workflow-osd-aws.yaml
@@ -11,6 +11,8 @@ spec:
         value: "4"
       - name: machine-type
         value: "m5.xlarge"
+      - name: aws-region
+        value: "us-west-2"
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -38,7 +40,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.6.13
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.9.7-1-ge4b4757607-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -73,6 +75,8 @@ spec:
             value: "{{workflow.parameters.machine-type}}"
           - name: CREATION_SOURCE
             value: "infra"
+          - name: AWS_REGION
+            value: "{{workflow.parameters.aws-region}}"
         volumeMounts:
           - name: data
             mountPath: /data
@@ -123,7 +127,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.6.13
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.9.7-1-ge4b4757607-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -11,6 +11,8 @@ spec:
         value: "4"
       - name: machine-type
         value: "m5.xlarge"
+      - name: gcp-region
+        value: us-east1
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -38,7 +40,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.2.24
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.9.7-1-ge4b4757607-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -70,6 +72,8 @@ spec:
             value: "{{workflow.parameters.machine-type}}"
           - name: CREATION_SOURCE
             value: "infra"
+          - name: GCP_REGION
+            value: "{{workflow.parameters.gcp-region}}"
         volumeMounts:
           - name: data
             mountPath: /data
@@ -120,7 +124,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.2.24
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.9.7-1-ge4b4757607-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -126,7 +126,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.7
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -196,7 +196,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.7
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -126,7 +126,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -196,7 +196,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-2-g3da517fbf3-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -25,6 +25,10 @@ spec:
         value: ""
       - name: enable-psps
         value: ""
+      - name: gcp-region
+        value: ""
+      - name: gcp-zone
+        value: ""
 
   volumes:
     - name: credentials
@@ -122,7 +126,7 @@ spec:
               none: {}
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.8.0
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint
@@ -138,6 +142,8 @@ spec:
           - --creation-source=infra
           - --k8s-version={{workflow.parameters.k8s-version}}
           - --enable-psps={{workflow.parameters.enable-psps}}
+          - --gcp-region={{workflow.parameters.gcp-region}}
+          - --gcp-zone={{workflow.parameters.gcp-zone}}
         volumeMounts:
           - name: credentials
             mountPath: /tmp/google-credentials.json
@@ -190,7 +196,7 @@ spec:
             path: /data/tfvars
             optional: true
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.8.0
+        image: quay.io/stackrox-io/ci:automation-flavors-demo-0.9.0-1-g9a91981c31-snapshot
         imagePullPolicy: Always
         command:
           - /usr/bin/entrypoint


### PR DESCRIPTION
Related https://github.com/stackrox/automation-flavors/pull/181

Tested in PR cluster that provisioning works with default values and: 
- for demo flavors: `eu` and `us` zones
- for ROSA: `us-east-1` & `us-west-2` zones -> eu-central-1 did not have quota. Should anyone ever want to use that, we can address it then 🙃 
- for OSD: `us-east` variants. 
