### PR TITLE
fix: region and zone parameters should be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [NEXT RELEASE]
 
+## [0.8.10]
+
+- Adds a fix for `demo` and `qa-demo` flavors: Region parameters should be optional on cluster creation, defaults are set in UI and the flavor itself.
+
 ## [0.8.9]
 
 - Add region configuration to more flavors. This is now supported by all except ARO and AKS.

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -31,11 +31,13 @@
       description: GCP region
       help: GCP region to deploy infrastructure into.
       value: us-central1
+      kind: optional
 
     - name: gcp-zone
       description: GCP zone
       help: GCP zone to deploy infrastructure into.
       value: us-central1-b
+      kind: optional
 
   artifacts:
     - name: kubeconfig
@@ -108,11 +110,13 @@
       description: GCP region
       help: GCP region to deploy infrastructure into.
       value: us-central1
+      kind: optional
 
     - name: gcp-zone
       description: GCP zone
       help: GCP zone to deploy infrastructure into.
       value: us-central1-b
+      kind: optional
 
   artifacts:
     - name: kubeconfig


### PR DESCRIPTION
## Description
Fixes the new region and zone parameters and allows them to be optional. This caused a problem with the release automation: https://redhat-internal.slack.com/archives/CVANK5K5W/p1705510320169549

Apparently, you must specify non-optional values, even if we set a value in `flavors.yaml`: https://github.com/stackrox/infra/blob/blugo/fix-region-parameters/service/cluster/cluster.go#L834-L863

# Testing

Before the changes in this PR:
```
❯ infractl -k -e localhost:8443 create qa-demo bl-1150-test --lifespan 2h --arg 'main-image=quay.io/rhacs-eng/main:4.3.4-rc.1,central-db-image=quay.io/rhacs-eng/central-db:4.3.4-rc.1'
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
Error: rpc error: code = Unknown desc = parameter "gcp-region" was not provided
```

After the changes:
```
infractl -k -e localhost:8443 create qa-demo bl-1150-test --lifespan 2h --arg 'main-image=quay.io/rhacs-eng/main:4.3.4-rc.1,central-db-image=quay.io/rhacs-eng/central-db:4.3.4-rc.1'
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
ID: bl-1150-test
```