### PR TITLE
chore(CI): use RH SA

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Authenticate to GCloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_INFRA_CI_AUTOMATION_SA }}
+          credentials_json: ${{ secrets.INFRA_CI_AUTOMATION_GCP_SA }}
 
       - name: Set up Cloud SDK
         uses: "google-github-actions/setup-gcloud@v2"


### PR DESCRIPTION
Re: https://github.com/stackrox/automation-iac/pull/64. The new credential was added to GHA secrets including for dependabot.