### PR TITLE
chore: use RH SA for gitops-deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,14 +43,12 @@ jobs:
       - name: Authenticate to GCloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_INFRA_DEPLOY_AUTOMATION_SA }}
-          project_id: ${{ env.PROJECT }}
+          credentials_json: ${{ secrets.INFRA_DEPLOY_AUTOMATION_GCP_SA }}
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: "gke-gcloud-auth-plugin"
-          project_id: ${{ env.PROJECT }}
 
       - name: Deploy to ${{ inputs.environment }}
         env:


### PR DESCRIPTION
Per title. The replacement SA is in a new GHA secret. 
Tested with deployment to dev: https://github.com/stackrox/infra/actions/runs/8072643133
IaC PR: https://github.com/stackrox/automation-iac/pull/66