### PR TITLE
ROX-22812: automatically bump the infra version on commit to master

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,22 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          tag_prefix: ""
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 # Changelog
 
-Entries in this file should be limited to:
-
-- Any changes that introduce a deprecation in functionality, OR
-- Obscure side-effects that are not obviously apparent based on the JIRA associated with the changes.
-Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
-
-## [NEXT RELEASE]
+This CHANGELOG is abandoned in favor of auto-generated release notes.
+Please see the release description for change information.
 
 ## [0.8.14]
 


### PR DESCRIPTION
This is similar to automation-flavors. 

I suggest to abandon the CHANGELOG. 