### PR TITLE
fix: --rhacs flag can be redefined in qa-demo flavor

### DIFF
--- a/cmd/infractl/cluster/create/command.go
+++ b/cmd/infractl/cluster/create/command.go
@@ -74,6 +74,8 @@ func Command() *cobra.Command {
 	for _, osArg := range os.Args {
 		if strings.Contains(osArg, "qa-demo") {
 			cmd.Flags().Bool("rhacs", false, "use Red Hat branded images for qa-demo (the default is to use open source images)")
+			// Abort loop if found, otherwise 'infractl create qa-demo prefix-qa-demo' will attempt to add another --rhacs flag.
+			break
 		}
 	}
 	return cmd


### PR DESCRIPTION
This flag can be defined twice, when calling `infractl create qa-demo something-qa-demo`.
Breaking the loop after the first occurrence (which must be the flavor, because the `infractl create FLAVOR [NAME]`) fixes this issue.

Found during smoke testing https://github.com/stackrox/infra/actions/runs/8156066579/job/22295815499.

I will deploy the resulting release from master, as this is a user-facing bug (and blocks #1203 ). 