### PR TITLE
chore: Bump version for automation-flavors#11

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,5 +8,5 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.3.4
-  automationFlavorsVersion: 0.10.4
+  automationFlavorsVersion: 0.0.9-tm-stuff.0
   ocpCredentialsMode: Passthrough


### PR DESCRIPTION
Auto-generated: Bump automation-flavors version for https://github.com/stackrox/automation-flavors/pull/11.