### PR TITLE
fix(ROX-15587): expose metrics on different port to rest of server

### DIFF
--- a/chart/infra-server/templates/deployment.yaml
+++ b/chart/infra-server/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+            - name: metrics
+              containerPort: 9101
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /configuration

--- a/config/config.go
+++ b/config/config.go
@@ -69,10 +69,12 @@ type AuthOidcConfig struct {
 // ServerConfig represents the configuration used for running the HTTP & GRPC
 // servers, and providing TLS.
 type ServerConfig struct {
-	Port      int    `json:"port"`
-	CertFile  string `json:"cert"`
-	KeyFile   string `json:"key"`
-	StaticDir string `json:"static"`
+	Port                    int    `json:"port"`
+	CertFile                string `json:"cert"`
+	KeyFile                 string `json:"key"`
+	StaticDir               string `json:"static"`
+	MetricsPort             int    `json:"metricsPort"`
+	MetricsIncludeHistogram bool   `json:"metricsIncludeHistogram"`
 }
 
 // SlackConfig represents the configuration used for sending cluster lifecycle

--- a/server/server.go
+++ b/server/server.go
@@ -85,12 +85,12 @@ func (s *server) RunServer() (<-chan error, error) {
 
 	// Metrics server
 	go func() {
-		// TODO: make port configurable
-		listenAddress := fmt.Sprintf("0.0.0.0:%d", 9101)
+		listenAddress := fmt.Sprintf("0.0.0.0:%d", s.cfg.Server.MetricsPort)
 		log.Infow("starting metrics server", "listenAddress", listenAddress)
 
-		// TODO: make time histogram data collection configurable
-		grpc_prometheus.EnableHandlingTimeHistogram()
+		if s.cfg.Server.MetricsIncludeHistogram {
+			grpc_prometheus.EnableHandlingTimeHistogram()
+		}
 		grpc_prometheus.Register(server)
 
 		mux := http.NewServeMux()


### PR DESCRIPTION
Moved metrics to a different port, so they aren't world-readable anymore.

Verify with the cluster linked in the comment below:

* `kubectl port-forward deploy/infra-server-deployment -n infra 9101:9101`
* Access https://localhost:9101/metrics