### PR TITLE
fix: Double OCP 3.11 create phase timeout

### DIFF
--- a/chart/infra-server/static/workflow-openshift-multi.yaml
+++ b/chart/infra-server/static/workflow-openshift-multi.yaml
@@ -54,7 +54,7 @@ spec:
                   from: '{{ "{{" }}steps.create.outputs.artifacts.terraform-destroy-plan{{ "}}" }}'
 
     - name: create
-      activeDeadlineSeconds: 3600
+      activeDeadlineSeconds: 7200
       inputs:
         parameters:
           - name: name


### PR DESCRIPTION
Two subsequent cluster creations failed due to 1h timeout. 
Doubling the timeout for the `create` phase should be sufficient.  

Context: https://redhat-internal.slack.com/archives/CMH5M8MHN/p1710418272486319