### PR TITLE
ROX-15587: enable prometheus persistence

### DIFF
--- a/chart/infra-monitoring/values.yaml
+++ b/chart/infra-monitoring/values.yaml
@@ -13,6 +13,8 @@ kube-prometheus:
       enabled: false
 
   prometheus:
+    persistence:
+      enabled: true
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
Another tiny increment.

Proof:

```
$ kubectl get pvc -n monitoring
NAME                                                                                                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
prometheus-prometheus-stack-kube-prom-prometheus-db-prometheus-prometheus-stack-kube-prom-prometheus-0   Bound    pvc-fa75280f-e094-4318-a629-628196eb13a9   8Gi        RWO            standard-rwo   67m
```