### PR TITLE
fix: destroy openshift-4-demo & openshift-4-perf-scale clusters

### DIFF
--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -269,6 +269,7 @@ spec:
           - entrypoint.sh
         args:
           - destroy
+          - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -167,6 +167,7 @@ spec:
           - entrypoint.sh
         args:
           - destroy
+          - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'
         env:
           - name: GOOGLE_CREDENTIALS
             valueFrom:


### PR DESCRIPTION
## Description

https://github.com/stackrox/automation-flavors/pull/191 (and https://github.com/stackrox/infra/pull/1168) introduced a requirement to specify the cluster name in the `destroy` step of the `openshift-4-demo` and `openshift-4-perf-scale` flavors. I suspect since https://github.com/stackrox/infra/pull/1184 was merged, all `openshift-4-demo` clusters have been leaking.

These changes add the cluster name to the `destroy` step in the `openshift-4-demo` and `openshift-4-perf-scale` flavors.