### PR TITLE
chore: remove unneeded secret values

### DIFF
--- a/chart/infra-server/templates/aws/secrets.yaml
+++ b/chart/infra-server/templates/aws/secrets.yaml
@@ -10,7 +10,3 @@ data:
     {{ .Values.aws.accessKeyId | b64enc }}
   AWS_SECRET_ACCESS_KEY: |-
     {{ .Values.aws.secretAccessKey | b64enc }}
-  REDHAT_PULL_SECRET_BASE64: |-
-    {{ .Values.aws.redHatPullSecretBase64 | b64enc }}
-  OPENSHIFT_CLUSTER_MANAGER_API_TOKEN: |-
-    {{ .Values.aws.openshiftClusterManagerApiToken | b64enc }}

--- a/cmd/infractl/cluster/utils/validate.go
+++ b/cmd/infractl/cluster/utils/validate.go
@@ -67,7 +67,7 @@ func ValidateParameterArgument(parts []string) error {
 	if value == "" {
 		return errors.New("value is empty")
 	}
-	match, err = regexp.MatchString(`^[a-zA-Z0-9:?/.-]+$`, value)
+	match, err = regexp.MatchString(`^[a-zA-Z0-9:?/.-_]+$`, value)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
osd-on-aws is getting these values from osd-access-secrets: https://github.com/stackrox/infra/blob/master/chart/infra-server/static/workflow-osd-aws.yaml#L62-L71