### PR TITLE
fix: extend deadline for roxctl pulls from quay.io

### DIFF
--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -54,7 +54,7 @@ spec:
                   from: '{{ "{{" }}workflow.outputs.artifacts.global-tfvars{{ "}}" }}'
 
     - name: roxctl
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 600
       outputs:
         artifacts:
           - name: roxctl

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -63,7 +63,7 @@ spec:
                   from: '{{ "{{" }}workflow.outputs.artifacts.global-tfvars{{ "}}" }}'
 
     - name: roxctl
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 600
       outputs:
         artifacts:
           - name: roxctl


### PR DESCRIPTION
From experience with CI (and a recent infra flake) we known that quya.io pulls can be quite slow. 