### PR TITLE
fix: extend other deadlines for roxctl pulls from quay.io

### DIFF
--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -283,7 +283,7 @@ spec:
             mountPath: /data
 
     - name: roxctl-central
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 600
       outputs:
         artifacts:
           - name: roxctl-central
@@ -300,7 +300,7 @@ spec:
           - /tmp/roxctl-central
 
     - name: roxctl-secured-cluster-services
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 600
       outputs:
         artifacts:
           - name: roxctl-secured-cluster-services


### PR DESCRIPTION
Missed with #1259.