### PR TITLE
fix: get only the most recent tag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO111MODULE=on
 all: image
 
 TAG=$(shell git describe --tags --abbrev=10 --long)
-TAGGED=$(shell git tag --contains | head)
+TAGGED=$(shell git tag --sort=-creatordate --contains | head --lines=1)
 ifneq (,$(TAGGED))
 	# We're tagged. Use the tag explicitly.
 	VERSION := $(TAGGED)


### PR DESCRIPTION
## Description

When multiple tags are associated with the current commit, the `TAGGED` in the Makefile will contain more than one tag. Any time we use this variable, we assume that there is only one tag.

These changes explicitly get the most recent tag and only one tag associated with the current commit.

Slack thread: https://redhat-internal.slack.com/archives/C04KV7S8KHV/p1713466775971019