### PR TITLE
fix: allow hyphen in create token

### DIFF
--- a/cmd/infractl/token/command.go
+++ b/cmd/infractl/token/command.go
@@ -34,12 +34,12 @@ func validateName(name string) error {
 	if name == "" {
 		return errors.New("no name given")
 	}
-	match, err := regexp.MatchString(`^[a-zA-Z][a-zA-Z ]*$`, name)
+	match, err := regexp.MatchString(`^[a-zA-Z][a-zA-Z -]*$`, name)
 	if err != nil {
 		return err
 	}
 	if !match {
-		return errors.New("name must be a non-empty alphabetical string")
+		return errors.New("name must be a non-empty alphabetical string (allowed special chars: space, hyphen)")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Many of our service account tokens have hyphens in the token name, which were generated before the validation changes. This PR allows us to renew those tokens