### PR TITLE
ROX-22710: switch to new bucket

### DIFF
--- a/chart/infra-server/templates/argo/secrets.yaml
+++ b/chart/infra-server/templates/argo/secrets.yaml
@@ -12,7 +12,7 @@ data:
     artifactRepository:
       archiveLogs: true
       gcs:
-        bucket: argo-artifacts-development
+        bucket: rhacs-infra-artifacts
         serviceAccountKeySecret:
           name: gcs-credentials
           key: credentials.json


### PR DESCRIPTION
Used in:
- Argo config for the artifacts destination:
https://github.com/stackrox/infra/blob/3e108306afcf0bed2ddf21a046e56cd74f31cee3/chart/infra-server/templates/argo/secrets.yaml#L15
- Signed URLs for artifacts download:
https://github.com/stackrox/infra/blob/3e108306afcf0bed2ddf21a046e56cd74f31cee3/signer/signer.go#L70
- The Infra server reads the artifacts to handle special tags for URL and connect string.

Requires https://github.com/stackrox/automation-iac/pull/117

## Testing performed

- [x] created clusters in current infra (dev) with URL/connect artifacts (as these have special handling (GCS copy) by infra-server). GKE and openshift-4-demo.
- [x] copied artifacts from prior location for clusters under test.
- [x] renamed artifacts from prior location for clusters under test (ensure infra is not referencing the prior bucket in workflows). clusters under test now fail to provide artifacts.
- [x] update secret for artifact access for dev infra. `google_credentials_json`.
  - ~used `ENVIRONMENT=development make secrets-edit`~ this created an invalid secret
  - used `ENVIRONMENT=development make secrets-download`
  - and input from IaC:
  - `terragrunt output -raw artifacts_sa_private_key_json`
  - used `ENVIRONMENT=development make secrets-upload`
- [x] changed dev infra to dev version.
- [ ] verify artifacts for clusters under test from new location. :red_circle:  Existing workflows directly reference the v1 artifact bucket.

Try again.

- [x] gave the artifacts SA access to v1 bucket in https://github.com/stackrox/automation-iac/pull/117
- [x] verified that artifacts for clusters created prior to migration are still accessible - i.e. existing clusters survive the migration
- [x] create new clusters and verify:
  - [x] artifacts are usable
  - [x] artifacts are in the [v2 bucket](https://console.cloud.google.com/storage/browser/rhacs-infra-artifacts/gj-05-21-caring-vessel-resto-69dt9/gj-05-21-caring-vessel-resto-69dt9-1320285247?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=acs-team-automation&prefix=&forceOnObjectsSortingFiltering=false)
