### PR TITLE
ROX-22599: Move secrets to RH GCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,23 +257,23 @@ bounce-argo-pods:
 ## Secrets ##
 #############
 .PHONY: secrets-download
-secrets-download: pre-check
+secrets-download:
 	@./scripts/deploy/secrets.sh download_secrets $(ENVIRONMENT)
 
 .PHONY: secrets-upload
-secrets-upload: pre-check
+secrets-upload:
 	@./scripts/deploy/secrets.sh upload_secrets $(ENVIRONMENT) $(SECRET_VERSION)
 
 .PHONY: secrets-show
-secrets-show: pre-check
+secrets-show:
 	@./scripts/deploy/secrets.sh show $(ENVIRONMENT) $(SECRET_VERSION)
 
 .PHONY: secrets-edit
-secrets-edit: pre-check
+secrets-edit:
 	@./scripts/deploy/secrets.sh edit $(ENVIRONMENT) $(SECRET_VERSION)
 
 .PHONY: secrets-revert
-secrets-revert: pre-check
+secrets-revert:
 	@./scripts/deploy/secrets.sh revert $(ENVIRONMENT) $(SECRET_VERSION)
 
 ##################

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -6,17 +6,7 @@ TASK="$1"
 ENVIRONMENT="$2"
 SECRET_VERSION="${3:-latest}"
 
-PROJECT="stackrox-infra"
-
-check_not_empty() {
-    for V in "$@"; do
-        typeset -n VAR="$V"
-        if [ -z "${VAR:-}" ]; then
-            echo "ERROR: Variable $V is not set or empty"
-            exit 1
-        fi
-    done
-}
+PROJECT="${INFRA_GCP_PROJECT:-acs-team-automation}"
 
 # Downloads secrets files for an ENVIRONMENT.
 download_secrets() {
@@ -96,5 +86,4 @@ revert() {
     upload_secrets
 }
 
-check_not_empty TASK ENVIRONMENT
 eval "$TASK"


### PR DESCRIPTION
Changes the deploy script to use secrets from the RH GCP project. Testing detailed in https://github.com/stackrox/automation-iac/pull/121.
