### PR TITLE
Use e2-standard-8 by default for GKE clusters

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -157,7 +157,7 @@
 
     - name: machine-type
       description: node machine type
-      value: e2-standard-4
+      value: e2-standard-8
       kind: optional
 
     - name: k8s-version


### PR DESCRIPTION
Use e2-standard-8 instances by default instead of e2-standard-4 to allow a full StackRox (including Scanner V4) to be deployed, just like a customer would deploy it.
