### PR TITLE
fix: use secrets from new project

### DIFF
--- a/chart/infra-server/templates/demo-certifier.yaml
+++ b/chart/infra-server/templates/demo-certifier.yaml
@@ -69,7 +69,7 @@ spec:
               - --cert-name=demos.rox.systems
               - --gcs-bucket=sr-demo-files
               - --gcs-prefix=certs
-              - --dns-gcp-project=acs-team-temp-dev
+              - --gcp-project-name=acs-team-temp-dev
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /configuration/google-credentials.json

--- a/scripts/deploy/helm.sh
+++ b/scripts/deploy/helm.sh
@@ -11,7 +11,7 @@ SECRET_VERSION="${4:-latest}"
 # Cannot use CI, because then CD with GHA would not be possible.
 TEST_MODE="${TEST_MODE:-false}"
 
-SECRETS_PROJECT="stackrox-infra"
+SECRETS_PROJECT="acs-team-automation"
 RELEASE_NAMESPACE="infra"
 RELEASE_NAME="infra-server"
 


### PR DESCRIPTION
Noticed two issues while [debugging](https://redhat-internal.slack.com/archives/CVANK5K5W/p1718622040012109) `demo` flavor:

- demo certifier for rox.systems did not complete: `flag provided but not defined: -dns-gcp-project`
- we were still using the secrets from the old project to deploy infra, even when the secrets management had already moved to the new project.