### PR TITLE
Adds quiet flag to infractl list

### DIFF
--- a/cmd/infractl/cluster/list/command.go
+++ b/cmd/infractl/cluster/list/command.go
@@ -36,6 +36,7 @@ func Command() *cobra.Command {
 
 	cmd.Flags().Bool("all", false, "include clusters not owned by you")
 	cmd.Flags().Bool("expired", false, "include expired clusters")
+	cmd.Flags().BoolP("quiet", "q", false, "only output cluster names")
 	cmd.Flags().String("prefix", "", "only include clusters whose names matches this prefix")
 	return cmd
 }
@@ -43,6 +44,7 @@ func Command() *cobra.Command {
 func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, _ []string) (common.PrettyPrinter, error) {
 	includeAll := common.MustBool(cmd.Flags(), "all")
 	includeExpired := common.MustBool(cmd.Flags(), "expired")
+	quietMode := common.MustBool(cmd.Flags(), "quiet")
 	prefix, _ := cmd.Flags().GetString("prefix")
 
 	req := v1.ClusterListRequest{
@@ -56,5 +58,8 @@ func run(ctx context.Context, conn *grpc.ClientConn, cmd *cobra.Command, _ []str
 		return nil, err
 	}
 
-	return prettyClusterListResponse(*resp), nil
+	return prettyClusterListResponse{
+		ClusterListResponse: *resp,
+		QuietMode:           quietMode,
+	}, nil
 }

--- a/cmd/infractl/cluster/list/command.go
+++ b/cmd/infractl/cluster/list/command.go
@@ -20,7 +20,10 @@ $ infractl list --expired
 $ infractl list --all
 
 # List clusters whose name matches a prefix.
-$ infractl list --prefix=<match>`
+$ infractl list --prefix=<match>
+
+# List only the names of clusters
+$ infractl list --quiet`
 
 // Command defines the handler for infractl list.
 func Command() *cobra.Command {

--- a/cmd/infractl/cluster/list/fancy.go
+++ b/cmd/infractl/cluster/list/fancy.go
@@ -11,7 +11,10 @@ import (
 	v1 "github.com/stackrox/infra/generated/api/v1"
 )
 
-type prettyClusterListResponse v1.ClusterListResponse
+type prettyClusterListResponse struct {
+	v1.ClusterListResponse
+	QuietMode bool
+}
 
 func (p prettyClusterListResponse) PrettyPrint(cmd *cobra.Command) {
 	for _, cluster := range p.Clusters {
@@ -23,15 +26,17 @@ func (p prettyClusterListResponse) PrettyPrint(cmd *cobra.Command) {
 		)
 
 		cmd.Printf("%s \n", cluster.GetID())
-		cmd.Printf("  Flavor:      %s\n", cluster.GetFlavor())
-		cmd.Printf("  Owner:       %s\n", cluster.GetOwner())
-		cmd.Printf("  Description: %s\n", cluster.GetDescription())
-		cmd.Printf("  Status:      %s\n", cluster.GetStatus())
-		cmd.Printf("  Created:     %v\n", common.FormatTime(createdOn))
-		if destroyedOn.Unix() != 0 {
-			cmd.Printf("  Destroyed:   %v\n", common.FormatTime(destroyedOn))
+		if !p.QuietMode {
+			cmd.Printf("  Flavor:      %s\n", cluster.GetFlavor())
+			cmd.Printf("  Owner:       %s\n", cluster.GetOwner())
+			cmd.Printf("  Description: %s\n", cluster.GetDescription())
+			cmd.Printf("  Status:      %s\n", cluster.GetStatus())
+			cmd.Printf("  Created:     %v\n", common.FormatTime(createdOn))
+			if destroyedOn.Unix() != 0 {
+				cmd.Printf("  Destroyed:   %v\n", common.FormatTime(destroyedOn))
+			}
+			cmd.Printf("  Lifespan:    %s\n", common.FormatExpiration(remaining))
 		}
-		cmd.Printf("  Lifespan:    %s\n", common.FormatExpiration(remaining))
 	}
 }
 


### PR DESCRIPTION
I use a few shell aliases and functions to ease my interaction with infra-created clusters. In order to make it a little easier to process existing clusters (e.g. automatically passing the cluster name to other commands), I've added a 'quiet' flag to `infractl list`, which only prints the cluster ID (name.)

I've not modified the json output at all, since it didn't feel as appropriate, but can add quiet mode support to that if requested.

I'm also open to better name suggestions for the flag itself.