### PR TITLE
fix(ROX-25537): pin openshift-multi to known good version

### DIFF
--- a/chart/infra-server/static/workflow-openshift-multi.yaml
+++ b/chart/infra-server/static/workflow-openshift-multi.yaml
@@ -99,7 +99,8 @@ spec:
             path: /well-known/artifacts/terraform-destroy.tfplan
 
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-multi-{{ .Chart.Annotations.automationFlavorsVersion }}
+        # TODO(ROX-25537): Fix build for openshift-multi
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-multi-0.10.12
         command:
           - /usr/bin/entrypoint
         args:
@@ -134,7 +135,8 @@ spec:
           - name: terraform-destroy-plan
             path: /well-known/artifacts/terraform-destroy.tfplan
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-openshift-multi-{{ .Chart.Annotations.automationFlavorsVersion }}
+        # TODO(ROX-25537): Fix build for openshift-multi
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-multi-0.10.12
         command:
           - /usr/bin/entrypoint
         args:


### PR DESCRIPTION
Openshift 3.11 build is broken due to base image EOL. Instead of attempting to fix, we disable the image build in https://github.com/stackrox/automation-flavors/pull/250 and pin the flavor image version to the last known good version, with the intention of fixing this in https://issues.redhat.com/browse/ROX-25537, should the need to update the image flavor ever arise.

