### PR TITLE
chore: releases link instead of changelog

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,7 +86,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": ":ship::tada:*Infra (${{ inputs.environment }}) was updated to ${{ inputs.version }}, ${{ github.server_url }}/${{ github.repository }}/releases."
+                      "text": ":ship::tada:*Infra (${{ inputs.environment }}) was updated to <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.version }}|${{ inputs.version }}>."
                     }
                   }
                 ]


### PR DESCRIPTION
The changelog was deprecated and the slack message can link to releases instead.

Example before this change: https://redhat-internal.slack.com/archives/CVANK5K5W/p1724950507607289