### PR TITLE
fix: allow unknown flavors in cost estimation

### DIFF
--- a/scripts/cost-estimation/render_costs.py
+++ b/scripts/cost-estimation/render_costs.py
@@ -7,6 +7,7 @@ from tabulate import tabulate
 DAILY_COST_MAP = {
     "demo": 33,
     "gke-default": 10,
+    "ibmroks": 56,
     "openshift-4": 29,
     "openshift-4-demo": 53,
     "openshift-4-perf-scale": 70,
@@ -14,7 +15,8 @@ DAILY_COST_MAP = {
     "osd-on-gcp": 35,
     "qa-demo": 33,
     "osd-on-aws": 50,
-    "rosa": 97,
+    "rosa": 40,
+    "rosahcp": 23,
     "eks": 13,
     "aks": 17,
     "aro": 53,


### PR DESCRIPTION
```
$ ./calculate-costs.sh 
Traceback (most recent call last):
  File "/Users/house/dev/stack/infra/scripts/cost-estimation/./render_costs.py", line 64, in <module>
    main()
  File "/Users/house/dev/stack/infra/scripts/cost-estimation/./render_costs.py", line 49, in main
    cost_per_flavor_env = calculate_costs(usage)
                          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/house/dev/stack/infra/scripts/cost-estimation/./render_costs.py", line 42, in calculate_costs
    current["cost (usd)"] = float(x["total_days_consumed"]) * DAILY_COST_MAP[x["flavor"]]
                                                              ~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'ibmroks'
```