### PR TITLE
chore: not parallel bats tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ unit-test: proto-generated-srcs
 .PHONY: bats-e2e-tests
 bats-e2e-tests:
 	@kubectl apply -f "workflows/*.yaml"
-	@bats --no-parallelize-within-files --recursive .
+	@bats --recursive .
 
 .PHONY: go-e2e-tests
 go-e2e-tests: proto-generated-srcs


### PR DESCRIPTION
Stop needing `parallel`. If the tests become too slow and can be parallelized, then we can add it at that time or move more tests out of bats.

* some tests were moved to golang and are parallel: https://github.com/stackrox/infra/pull/777
  * `@go test ./test/e2e/... -tags=e2e -v -parallel 5 -count 1 -cover -timeout 1h` https://github.com/stackrox/infra/blob/master/Makefile#L188
* as-is a bats arg disables parallel for tests within a file: `@bats --jobs 5 --no-parallelize-within-files --recursive .`