### PR TITLE
fix: use command defined in image

### DIFF
--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -51,7 +51,7 @@ spec:
         image: quay.io/stackrox-io/ci:automation-flavors-aks-{{ .Chart.Annotations.automationFlavorsVersion }}
         imagePullPolicy: Always
         command:
-          - entrypoint
+          - entrypoint.sh
         args:
           - create
           - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'
@@ -99,7 +99,7 @@ spec:
         image: quay.io/stackrox-io/ci:automation-flavors-aks-{{ .Chart.Annotations.automationFlavorsVersion }}
         imagePullPolicy: Always
         command:
-          - entrypoint
+          - entrypoint.sh
         args:
           - destroy
           - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'


### PR DESCRIPTION
~~aks command was hardcoded as 'entrypoint' in the argo workflow, remove this and use the image's defined command+entrypoint~~
I renamed the `entrypoint` script to `entrypoint.sh` on aks.