### PR TITLE
chore(toil improvement): add script to find demo clusters for obscurely named VMs

### DIFF
--- a/scripts/orphan-clusters/find-demo-clusters-for-vms.sh
+++ b/scripts/orphan-clusters/find-demo-clusters-for-vms.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script finds infra cluster names for obscure VM prefixes from the Janitor control output
+# gcloud compute instances list --project acs-team-temp-dev --format json | jq -r '.[].name' | sed 's/gke-//; s/-default-pool.*//; s/-master.*//; s/-worker.*//' | sort | uniq
+
+set -euo pipefail
+
+if [[ "$#" -lt "1" ]]; then
+	>&2 echo "Usage: find-demo-clusters-for-vms.sh <VM prefix>"
+	exit 6
+fi
+
+CLUSTER="$1"
+INSTANCE=$(gcloud compute instances list --project acs-team-temp-dev --format json \
+  | jq -r '.[].name' \
+  | grep "^gke-${CLUSTER}.*" \
+  | head -n 1)
+
+gcloud compute instances describe "${INSTANCE}" --project acs-team-temp-dev --format json | jq -r '.labels.name'


### PR DESCRIPTION
Some VMs from our manual GCP VM check have weird names that are not obvious matches to infra clusters.
They come from the `demo` flavor.
This very basic script finds the infra cluster that owns these resources.

Example: `./scripts/orphan-clusters/find-demo-clusters-for-vms.sh ztdlgvpq`