### PR TITLE
ROX-27432: allow regex in authentication claimrules

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           ENVIRONMENT=development TEST_MODE=true make install-argo clean-argo-config install-monitoring helm-deploy
           sleep 10 # wait for old pods to disappear so the svc port-forward doesn't connect to them
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 &
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
           sleep 10
 
           kubectl -n infra logs -l app=infra-server --tail=-1
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check the deployment
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 &
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
           sleep 10
 
           version="$($INFRACTL version --json)"
@@ -157,7 +157,7 @@ jobs:
         env:
           INFRA_TOKEN: ${{ secrets.INFRA_TOKEN_DEV }}
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 &
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
           sleep 5
 
           $INFRACTL whoami || true
@@ -173,6 +173,6 @@ jobs:
         env:
           INFRA_TOKEN: ${{ secrets.INFRA_TOKEN_DEV }}
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 &
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
           sleep 5
           make go-e2e-tests

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           ENVIRONMENT=development TEST_MODE=true make install-argo clean-argo-config install-monitoring helm-deploy
           sleep 10 # wait for old pods to disappear so the svc port-forward doesn't connect to them
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 > /dev/null 2>&1 &
           sleep 10
 
           kubectl -n infra logs -l app=infra-server --tail=-1
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check the deployment
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 > /dev/null 2>&1 &
           sleep 10
 
           version="$($INFRACTL version --json)"
@@ -157,7 +157,7 @@ jobs:
         env:
           INFRA_TOKEN: ${{ secrets.INFRA_TOKEN_DEV }}
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 > /dev/null 2>&1 &
           sleep 5
 
           $INFRACTL whoami || true
@@ -173,6 +173,6 @@ jobs:
         env:
           INFRA_TOKEN: ${{ secrets.INFRA_TOKEN_DEV }}
         run: |
-          kubectl -n infra port-forward svc/infra-server-service 8443:8443 & > /dev/null 2>&1
+          kubectl -n infra port-forward svc/infra-server-service 8443:8443 > /dev/null 2>&1 &
           sleep 5
           make go-e2e-tests

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ nohup.out
 test/mocks
 __debug_bin*
 .DS_Store
+report.xml

--- a/auth/claimrule/claim_rule.go
+++ b/auth/claimrule/claim_rule.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jeremywohl/flatten/v2"
@@ -70,8 +71,13 @@ func (cr *ClaimRule) equalCheck(flatTokenClaims map[string]interface{}, jsonPath
 		return errors.Errorf("expected claim %q is not found", jsonPath)
 	}
 
-	if cr.Value != tokenClaimValue {
+	pattern := fmt.Sprintf("^%s$", cr.Value)
+	found, err := regexp.MatchString(pattern, tokenClaimValue.(string))
+	if !found {
 		return errors.Errorf("expected claim %q is not correct", jsonPath)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "error matching claim %s to expected value", tokenClaimValue)
 	}
 
 	return nil

--- a/auth/claimrule/claim_rule_test.go
+++ b/auth/claimrule/claim_rule_test.go
@@ -164,6 +164,39 @@ func getDataSets() map[string]dataSet {
 			}},
 			err: true,
 		},
+		"eq-regex-match": {
+			tokenClaims: map[string]interface{}{
+				"field": "val1",
+			},
+			rules: ClaimRules{{
+				Value: "(val1|val2)",
+				Path:  "field",
+				Op:    "eq",
+			}},
+			err: false,
+		},
+		"eq-regex-no-match": {
+			tokenClaims: map[string]interface{}{
+				"field": "val3",
+			},
+			rules: ClaimRules{{
+				Value: "(val1|val2)",
+				Path:  "field",
+				Op:    "eq",
+			}},
+			err: true,
+		},
+		"in-regex-match": {
+			tokenClaims: map[string]interface{}{
+				"field": []string{"val1", "val2"},
+			},
+			rules: ClaimRules{{
+				Value: "(val2|val3)",
+				Path:  "field",
+				Op:    "in",
+			}},
+			err: false,
+		},
 	}
 }
 

--- a/auth/claimrule/claim_rule_test.go
+++ b/auth/claimrule/claim_rule_test.go
@@ -186,6 +186,28 @@ func getDataSets() map[string]dataSet {
 			}},
 			err: true,
 		},
+		"eq-regex-no-match-substring-claim": {
+			tokenClaims: map[string]interface{}{
+				"field": "val",
+			},
+			rules: ClaimRules{{
+				Value: "val1",
+				Path:  "field",
+				Op:    "eq",
+			}},
+			err: true,
+		},
+		"eq-regex-no-match-substring-rule": {
+			tokenClaims: map[string]interface{}{
+				"field": "val23",
+			},
+			rules: ClaimRules{{
+				Value: "val2",
+				Path:  "field",
+				Op:    "eq",
+			}},
+			err: true,
+		},
 		"in-regex-match": {
 			tokenClaims: map[string]interface{}{
 				"field": []string{"val1", "val2"},


### PR DESCRIPTION
This allows multiple (Rover) groups to be specified in the OIDC configuration.