### PR TITLE
ROX-21529: attach stackroxinfra container registry to AKS

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,5 +8,5 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.6.1
-  automationFlavorsVersion: 0.10.38
+  automationFlavorsVersion: 0.10.39
   ocpCredentialsMode: Passthrough

--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -84,6 +84,8 @@ spec:
             value: '{{ "{{" }}workflow.parameters.network-policy{{ "}}" }}'
           - name: CREATION_SOURCE
             value: "infra"
+          - name: ACR_TO_ATTACH
+            value: "/subscriptions/3fe60802-349e-47c6-ba86-4d3bba2b5650/resourceGroups/stackrox-infra/providers/Microsoft.ContainerRegistry/registries/stackroxinfra"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -72,6 +72,11 @@ spec:
               secretKeyRef:
                 name: azure-secrets
                 key: AZURE_SP_TENANT
+          - name: ACR_TO_ATTACH
+            valueFrom:
+              secretKeyRef:
+                name: azure-secrets
+                key: ACR_TO_ATTACH
           - name: NODE_COUNT
             value: '{{ "{{" }}workflow.parameters.nodes{{ "}}" }}'
           - name: INSTANCE_TYPE
@@ -84,8 +89,6 @@ spec:
             value: '{{ "{{" }}workflow.parameters.network-policy{{ "}}" }}'
           - name: CREATION_SOURCE
             value: "infra"
-          - name: ACR_TO_ATTACH
-            value: "/subscriptions/3fe60802-349e-47c6-ba86-4d3bba2b5650/resourceGroups/stackrox-infra/providers/Microsoft.ContainerRegistry/registries/stackroxinfra"
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/templates/azure/secrets.yaml
+++ b/chart/infra-server/templates/azure/secrets.yaml
@@ -16,3 +16,5 @@ data:
     {{ .Values.azure.sp_password | b64enc }}
   AZURE_SP_TENANT: |-
     {{ .Values.azure.sp_tenant | b64enc }}
+  ACR_TO_ATTACH: |-
+    {{ .Values.azure.aks_attached_acr | b64enc }}


### PR DESCRIPTION
Attach `stackrox-infra` ACR to infra clusters.