### PR TITLE
fix(toil): enable more auto-merge for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       day: 'wednesday'
     reviewers:
       - 'stackrox/infra'
+    labels:
+      - 'auto-merge'
 
   - package-ecosystem: 'docker'
     directory: 'image/'
@@ -30,11 +32,15 @@ updates:
       day: 'wednesday'
     reviewers:
       - 'stackrox/infra'
+    labels:
+      - 'auto-merge'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: 'weekly'
       day: 'wednesday'
     reviewers:
-    - "stackrox/infra"
+    - 'stackrox/infra'
+    labels:
+      - 'auto-merge'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,17 +15,18 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: contains(github.event.pull_request.labels, 'auto-merge') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
-        run: gh pr merge --auto --squash "${PR_URL}"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          github-token: "${{ secrets.RHACS_BOT_GITHUB_TOKEN }}"
 
       - name: Approve a PR
         if: contains(github.event.pull_request.labels, 'auto-merge') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
         run: gh pr review --approve "${PR_URL}"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.RHACS_BOT_GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: contains(github.event.pull_request.labels, 'auto-merge') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "${PR_URL}"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,8 +17,15 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+        if: contains(github.event.pull_request.labels, 'auto-merge') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "${PR_URL}"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Approve a PR
+        if: contains(github.event.pull_request.labels, 'auto-merge') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr review --approve "${PR_URL}"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.RHACS_BOT_GITHUB_TOKEN}}


### PR DESCRIPTION
Enable full auto-merge for Dependabot PRs for 
- Go
- Docker
- GHA
- (not UI, fyi @stackrox/ui-dep-updaters )

I have checked the branch protection rules for `main`. It requires passing 
- lint
- unit test
- build
- e2e tests