### PR TITLE
fix: have all flavors delete themselves even in failure

### DIFF
--- a/chart/infra-server/static/test-connect-artifact.yaml
+++ b/chart/infra-server/static/test-connect-artifact.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: test-connect-artifact-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -16,8 +17,6 @@ spec:
             template: create
         - - name: wait
             template: wait
-        - - name: destroy
-            template: destroy
 
     - name: create
       outputs:

--- a/chart/infra-server/static/test-url-artifact.yaml
+++ b/chart/infra-server/static/test-url-artifact.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: test-url-artifact-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -16,8 +17,6 @@ spec:
             template: create
         - - name: wait
             template: wait
-        - - name: destroy
-            template: destroy
 
     - name: create
       outputs:

--- a/chart/infra-server/static/workflow-aks.yaml
+++ b/chart/infra-server/static/workflow-aks.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: aks-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -26,9 +27,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       outputs:

--- a/chart/infra-server/static/workflow-eks.yaml
+++ b/chart/infra-server/static/workflow-eks.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: eks-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -26,9 +27,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 3600

--- a/chart/infra-server/static/workflow-gke-default.yaml
+++ b/chart/infra-server/static/workflow-gke-default.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: gke-default-
 spec:
   entrypoint: start
+  onExit: stop
   arguments:
     parameters:
       - name: name
@@ -30,6 +31,9 @@ spec:
             template: create
         - - name: wait
             template: wait
+
+    - name: stop
+      steps:
         - - name: destroy
             template: destroy
             arguments:

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: openshift-4-demo-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -73,9 +74,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       container:

--- a/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-perf-scale.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: openshift-4-perf-scale-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -49,9 +50,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       outputs:

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: openshift-4-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -50,9 +51,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       outputs:

--- a/chart/infra-server/static/workflow-openshift-aro.yaml
+++ b/chart/infra-server/static/workflow-openshift-aro.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: aro-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -31,9 +32,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200

--- a/chart/infra-server/static/workflow-openshift-ibmroks.yaml
+++ b/chart/infra-server/static/workflow-openshift-ibmroks.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: roks-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -38,9 +39,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200

--- a/chart/infra-server/static/workflow-openshift-rosa-hcp.yaml
+++ b/chart/infra-server/static/workflow-openshift-rosa-hcp.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: rosa-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -39,9 +40,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200

--- a/chart/infra-server/static/workflow-openshift-rosa.yaml
+++ b/chart/infra-server/static/workflow-openshift-rosa.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: rosa-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -33,9 +34,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200

--- a/chart/infra-server/static/workflow-osd-aws.yaml
+++ b/chart/infra-server/static/workflow-osd-aws.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: rosa-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -33,9 +34,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: rosa-
 spec:
   entrypoint: start
+  onExit: destroy
   arguments:
     parameters:
       - name: name
@@ -33,9 +34,6 @@ spec:
 
         - - name: wait
             template: wait
-
-        - - name: destroy
-            template: destroy
 
     - name: create
       activeDeadlineSeconds: 7200


### PR DESCRIPTION
Some already did that. Some already clean up if they fail during create (like OCP). Still better to be consistent. This is a patch on an issue that should be solved properly. 