### PR TITLE
fix(infractl logs): pod running workflow node contains stage name

### DIFF
--- a/pkg/service/cluster/cluster.go
+++ b/pkg/service/cluster/cluster.go
@@ -706,7 +706,8 @@ func (s *clusterImpl) getLogs(ctx context.Context, node v1alpha1.NodeStatus) *v1
 		Message: node.Message,
 	}
 
-	stream, err := s.k8sPodsClient.GetLogs(node.ID, &corev1.PodLogOptions{
+	podName := determinePodName(node)
+	stream, err := s.k8sPodsClient.GetLogs(podName, &corev1.PodLogOptions{
 		Container:  "main",
 		Follow:     false,
 		Timestamps: true,
@@ -724,6 +725,13 @@ func (s *clusterImpl) getLogs(ctx context.Context, node v1alpha1.NodeStatus) *v1
 	log.Body = logBody
 
 	return log
+}
+
+func determinePodName(node v1alpha1.NodeStatus) string {
+	parts := strings.Split(node.ID, "-")
+	baseName := strings.Join(parts[:len(parts)-1], "-")
+	randomNumber := parts[len(parts)-1]
+	return fmt.Sprintf("%s-%s-%s", baseName, node.DisplayName, randomNumber)
 }
 
 func (s *clusterImpl) startSlackCheck() {

--- a/pkg/service/cluster/cluster.go
+++ b/pkg/service/cluster/cluster.go
@@ -731,7 +731,7 @@ func determinePodName(node v1alpha1.NodeStatus) string {
 	parts := strings.Split(node.ID, "-")
 	baseName := strings.Join(parts[:len(parts)-1], "-")
 	randomNumber := parts[len(parts)-1]
-	return fmt.Sprintf("%s-%s-%s", baseName, node.DisplayName, randomNumber)
+	return fmt.Sprintf("%s-%s-%s", baseName, node.TemplateName, randomNumber)
 }
 
 func (s *clusterImpl) startSlackCheck() {

--- a/test/e2e/cluster/helpers.go
+++ b/test/e2e/cluster/helpers.go
@@ -12,6 +12,7 @@ import (
 	infraClusterGet "github.com/stackrox/infra/cmd/infractl/cluster/get"
 	infraClusterLifespan "github.com/stackrox/infra/cmd/infractl/cluster/lifespan"
 	infraClusterList "github.com/stackrox/infra/cmd/infractl/cluster/list"
+	infraClusterLogs "github.com/stackrox/infra/cmd/infractl/cluster/logs"
 	infraWhoami "github.com/stackrox/infra/cmd/infractl/whoami"
 	utils "github.com/stackrox/infra/test/e2e"
 )
@@ -121,6 +122,20 @@ func infractlList(args ...string) (utils.ListClusterReponse, error) {
 		return jsonData, err
 	}
 	return jsonData, nil
+}
+
+func infractlLogs(clusterID string) (string, error) {
+	infraLogsCmd := infraClusterLogs.Command()
+	buf := utils.PrepareCommand(infraLogsCmd, false, clusterID)
+	err := infraLogsCmd.Execute()
+	if err != nil {
+		return "", err
+	}
+	logs, err := utils.RetrieveCommandOutput(buf)
+	if err != nil {
+		return "", err
+	}
+	return logs, nil
 }
 
 func infractlWhoami() (string, error) {

--- a/test/e2e/cluster/logs_test.go
+++ b/test/e2e/cluster/logs_test.go
@@ -26,6 +26,4 @@ func TestLogs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Containsf(t, logs, "create", "logs must contain an entry for the create stage")
 	assert.Containsf(t, logs, "msg=\"capturing logs\"", "logs must contain an entry confirming log collection")
-	assertStatusBecomes(t, clusterID, "FINISHED")
-	assert.Containsf(t, logs, "destroy", "logs must contain an entry for the destroy stage")
 }

--- a/test/e2e/cluster/logs_test.go
+++ b/test/e2e/cluster/logs_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+package cluster_test
+
+import (
+	"testing"
+
+	utils "github.com/stackrox/infra/test/e2e"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogs(t *testing.T) {
+	utils.CheckContext()
+	clusterID, err := infractlCreateCluster(
+		"simulate", utils.GetUniqueClusterName("logs"),
+		"--lifespan=30s",
+		"--arg=create-delay-seconds=5",
+		"--arg=destroy-delay-seconds=5",
+	)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, clusterID)
+	assertStatusBecomes(t, clusterID, "READY")
+
+	logs, err := infractlLogs(clusterID)
+	assert.NoError(t, err)
+	assert.Containsf(t, logs, "create", "logs must contain an entry for the create stage")
+	assert.Containsf(t, logs, "msg=\"capturing logs\"", "logs must contain an entry confirming log collection")
+	assertStatusBecomes(t, clusterID, "FINISHED")
+	assert.Containsf(t, logs, "destroy", "logs must contain an entry for the destroy stage")
+}


### PR DESCRIPTION
Clusters on infra.rox.systems don't show logs anymore, because the naming scheme of the workflow pod has changed, example: https://infra.rox.systems/cluster/infra-pr-1519

This change must have been introduced in one of the Argo version bumps that we did last week. 
Instead of the `node.ID` (node of the workflow graph), the name now includes the template name of the stage before the random part:

|||
|--|--|
| `node.ID` | `infra-pr-1519-p2lf7-2787033289` |
| pod | `infra-pr-1519-p2lf7-create-2787033289` |

Validated in the PR cluster for all flavors and added a test.