### PR TITLE
fix(ROX-28736): reduce Workflow TTL to 7 days

### DIFF
--- a/chart/infra-server/argo-values.yaml
+++ b/chart/infra-server/argo-values.yaml
@@ -12,10 +12,10 @@ argo-workflows:
           argo: workflows
       spec:
         ttlStrategy:
-          # Keep the workflow pods & logs available for 30 days
-          secondsAfterCompletion: 2592000
-          secondsAfterSuccess: 2592000
-          secondsAfterFailure: 2592000
+          # Keep the workflow objects available for 7 days
+          secondsAfterCompletion: 604800
+          secondsAfterSuccess: 604800
+          secondsAfterFailure: 604800
 
   artifactRepository:
     archiveLogs: true


### PR DESCRIPTION
Completed workflows (failed, successful, completed) should be removed after 7 days. This speeds up `infractl list [--all --expired --flavor ... --status ...]` operations, in my experiments halved the response time from ~10 to ~5 seconds.