### PR TITLE
Use an absolute base url for asset paths

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig(({ mode }) => {
       devServerPlugin(),
       sourcemapPlugin(),
       buildPathPlugin(),
-      basePlugin(),
       importPrefixPlugin(),
       htmlPlugin(mode),
 
@@ -119,20 +118,6 @@ function buildPathPlugin(): Plugin {
         build: {
           outDir: BUILD_PATH || 'build',
         },
-      };
-    },
-  };
-}
-
-// Migration guide: Follow the guide below and remove homepage field in package.json
-// https://vitejs.dev/config/shared-options.html#base
-function basePlugin(): Plugin {
-  return {
-    name: 'base-plugin',
-    config(_, { mode }) {
-      const { PUBLIC_URL } = loadEnv(mode, '.', ['PUBLIC_URL']);
-      return {
-        base: PUBLIC_URL || '',
       };
     },
   };


### PR DESCRIPTION
Autogenerated Vite configuration set the base URL for assets to `'.'`, which causes the bootstrap js/css path to be incorrect when visiting the app from anything other than the index. This removes that section of config, returning the path to its default base of `'/'`.

Tested by:

Visiting the build produced by this PR and verifying manually. 

Verified with a kubectl port forward against `infra-pr-1544` cluster. ✅ 