### PR TITLE
chore: add additional worker to the ocp flavors

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -266,7 +266,7 @@
 
     - name: worker-node-count
       description: number of worker nodes
-      value: 2
+      value: 3
       kind: optional
 
     - name: region


### PR DESCRIPTION
This is mostly due to the additional resources required by Scanner V4 being installed by default.