### PR TITLE
chore: set ssd as default storage class on ocp flavors

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -301,7 +301,7 @@
 
     - name: ssd-storage-class
       description: Ensure an SSD StorageClass is the default StorageClass for the cluster
-      value: false
+      value: true
       kind: optional
 
   artifacts:
@@ -452,7 +452,7 @@
 
     - name: ssd-storage-class
       description: Ensure an SSD StorageClass is the default StorageClass for the cluster
-      value: false
+      value: true
       kind: optional
 
   artifacts:
@@ -581,7 +581,7 @@
 
     - name: ssd-storage-class
       description: Ensure an SSD StorageClass is the default StorageClass for the cluster
-      value: false
+      value: true
       kind: optional
 
   artifacts:


### PR DESCRIPTION
Per discussion https://redhat-internal.slack.com/archives/C04KV7S8KHV/p1752674171680979