### PR TITLE
fix: switch bitnami Prometheus repos to legacy ones and fix alerts

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -15,5 +15,5 @@ dependencies:
     version: "0.45.9"
     repository: "https://argoproj.github.io/argo-helm"
   - name: kube-prometheus
-    version: 11.1.1
+    version: 11.3.10
     repository: https://charts.bitnami.com/bitnami

--- a/chart/infra-server/monitoring-values.yaml
+++ b/chart/infra-server/monitoring-values.yaml
@@ -1,6 +1,8 @@
 kube-prometheus:
   namespaceOverride: monitoring
   operator:
+    image:
+      repository: bitnamilegacy/prometheus-operator
     resources:
       limits:
         cpu: 100m
@@ -14,6 +16,8 @@ kube-prometheus:
       enabled: false
 
   prometheus:
+    image:
+      repository: bitnamilegacy/prometheus
     persistence:
       enabled: true
     resources:
@@ -45,6 +49,8 @@ kube-prometheus:
     enabled: false
 
   alertmanager:
+    image:
+      repository: bitnamilegacy/alertmanager
     resources:
       limits:
         cpu: 100m

--- a/chart/infra-server/requirements.lock
+++ b/chart/infra-server/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.45.9
 - name: kube-prometheus
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.1
-digest: sha256:46322f064751933585c0985dad77996ed8ee216df0fed19ea9c40f7935f67ae7
-generated: "2025-03-05T10:30:52.962223+01:00"
+  version: 11.3.10
+digest: sha256:59c5c412a14a5ce69cdc7745be5d37603ee0e7748608a586a2b812da4457e60a
+generated: "2025-10-01T13:00:11.143106+02:00"

--- a/chart/infra-server/templates/monitoring/alertmanager.yaml
+++ b/chart/infra-server/templates/monitoring/alertmanager.yaml
@@ -11,8 +11,15 @@ spec:
   route:
     receiver: 'slack-notifications'
     groupBy: [alertname, job, app]
+    routes:
+    - matchers:
+      - name: alertname
+        value: InfoInhibitor
+      receiver: 'null'
+      continue: false
 
   receivers:
+  - name: 'null'
   - name: 'slack-notifications'
     slackConfigs:
     - apiURL:

--- a/chart/infra-server/templates/monitoring/rules.yaml
+++ b/chart/infra-server/templates/monitoring/rules.yaml
@@ -10,7 +10,7 @@ spec:
     interval: 30s
     rules:
     - alert: Workflow Error
-      expr: increase(argo_workflows_count{status="Error"}[5m]) > 0
+      expr: increase(argo_workflows_gauge{status="Error"}[5m]) > 0
       for: 1m
       annotations:
         summary: A workflow has errored
@@ -20,7 +20,7 @@ spec:
         namespace: monitoring
         environment: {{ .Values.environment }}
     - alert: Workflow Failure
-      expr: increase(argo_workflows_count{status="Failed"}[5m]) > 0
+      expr: increase(argo_workflows_gauge{status="Failed"}[5m]) > 0
       for: 1m
       annotations:
         summary: A workflow has failed.


### PR DESCRIPTION
Couple problems solved here:
* Recent PRs failed to deploy infra chart, because Bitnami removed their images which we use in Monitoring stack (even in CI): https://github.com/bitnami/containers/issues/83267, example: #1665 . This needs to be fixed, otherwise we cannot deploy infra 😱 
* I bumped the monitoring chart in the process, because not all images were migrated IIUC, so latest should be fine. 
* When testing I noticed that we don't get alerts in #acs-infra-alerts anymore (probably since the last argo server upgrade), and solved that by fixing the metric name
* Then I got InfoInhibitor alerts sent to the same channel. We should ignore them, so I am sending them to null receiver. 

Further improvements (moving off `bitnamilegacy` repos) can be done in https://issues.redhat.com/browse/ROX-31121 (part of https://issues.redhat.com/browse/ROX-17433).