### PR TITLE
fix: do not deploy monitoring on PRs

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Deploy infra to dev cluster
         run: |
-          ENVIRONMENT=development TEST_MODE=true make helm-deploy
+          ENVIRONMENT=development TEST_MODE=true NO_MONITORING=true make helm-deploy
           sleep 10 # wait for old pods to disappear so the svc port-forward doesn't connect to them
           kubectl -n infra port-forward svc/infra-server-service 8443:8443 > /dev/null 2>&1 &
           sleep 10

--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -17,3 +17,4 @@ dependencies:
   - name: kube-prometheus
     version: 11.3.10
     repository: https://charts.bitnami.com/bitnami
+    condition: monitoring.enabled

--- a/chart/infra-server/requirements.lock
+++ b/chart/infra-server/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-prometheus
   repository: https://charts.bitnami.com/bitnami
   version: 11.3.10
-digest: sha256:8bd8d054f0dd6ceadad7052e86248b26f797fde52cb5bacaf15b8aee52f67e09
-generated: "2026-03-19T12:05:14.754127+01:00"
+digest: sha256:c1eecd7d0fe344ae55befc669d9eb0c81a7070ceafc8423f61ac62e34f797176
+generated: "2026-04-16T16:44:19.411515+02:00"

--- a/chart/infra-server/templates/monitoring/alertmanager.yaml
+++ b/chart/infra-server/templates/monitoring/alertmanager.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if eq .Values.testMode false -}}
+{{- if and (eq .Values.testMode false) .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:

--- a/chart/infra-server/templates/monitoring/rules.yaml
+++ b/chart/infra-server/templates/monitoring/rules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -29,3 +30,4 @@ spec:
         severity: 'info'
         namespace: monitoring
         environment: {{ .Values.environment }}
+{{- end }}

--- a/chart/infra-server/templates/monitoring/secrets.yaml
+++ b/chart/infra-server/templates/monitoring/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -6,3 +7,4 @@ metadata:
   namespace: monitoring
 data:
   webhookURL: "{{ .Values.alertmanagerSlackWebhook | b64enc }}"
+{{- end }}

--- a/chart/infra-server/templates/monitoring/servicemonitors.yaml
+++ b/chart/infra-server/templates/monitoring/servicemonitors.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -28,3 +29,4 @@ spec:
   selector:
     matchLabels:
       app: infra-server
+{{- end }}

--- a/chart/infra-server/values.yaml
+++ b/chart/infra-server/values.yaml
@@ -1,0 +1,3 @@
+# Default chart values. Override via --set or additional values files.
+monitoring:
+  enabled: true

--- a/scripts/deploy/helm.sh
+++ b/scripts/deploy/helm.sh
@@ -11,6 +11,13 @@ SECRET_VERSION="${4:-latest}"
 # Cannot use CI, because then CD with GHA would not be possible.
 TEST_MODE="${TEST_MODE:-false}"
 
+# When NO_MONITORING is true, skip kube-prometheus and chart monitoring resources.
+# monitoring.enabled is applied after --values - so merged secrets cannot re-enable it.
+HELM_MONITORING_FINAL_SET=()
+if [[ "${NO_MONITORING}" == "true" ]]; then
+    HELM_MONITORING_FINAL_SET=(--set monitoring.enabled=false)
+fi
+
 SECRETS_PROJECT="acs-team-automation"
 RELEASE_NAMESPACE="infra"
 RELEASE_NAME="infra-server"
@@ -48,6 +55,7 @@ template() {
         --set environment="${ENVIRONMENT}" \
         --set testMode="${TEST_MODE}" \
         --values - \
+        "${HELM_MONITORING_FINAL_SET[@]}" \
     < <(gcloud secrets versions access "${SECRET_VERSION}" \
         --secret "infra-values-${ENVIRONMENT}" \
         --project "${SECRETS_PROJECT}" \
@@ -73,6 +81,7 @@ deploy() {
         --set environment="${ENVIRONMENT}" \
         --set testMode="${TEST_MODE}" \
         --values - \
+        "${HELM_MONITORING_FINAL_SET[@]}" \
     < <(gcloud secrets versions access "${SECRET_VERSION}" \
         --secret "infra-values-${ENVIRONMENT}" \
         --project "${SECRETS_PROJECT}" \
@@ -98,6 +107,7 @@ diff() {
         --set environment="${ENVIRONMENT}" \
         --set testMode="${TEST_MODE}" \
         --values - \
+        "${HELM_MONITORING_FINAL_SET[@]}" \
     < <(gcloud secrets versions access "${SECRET_VERSION}" \
         --secret "infra-values-${ENVIRONMENT}" \
         --project "${SECRETS_PROJECT}" \


### PR DESCRIPTION
Context: After https://redhat-internal.slack.com/archives/CVANK5K5W/p1776348339795849, I noticed that Bitnami removed the images from https://hub.docker.com/r/bitnami/prometheus-operator. We use them to deploy Prometheus in infra clusters. We don't use monitoring in the PRs, so we can disable it while working on a permanent solution for master branch. 