### PR TITLE
fix(ROX-31121): Monitoring deployment from Prometheus Community chart

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - name: argo-workflows
     version: "1.0.4"
     repository: "https://argoproj.github.io/argo-helm"
-  - name: kube-prometheus
-    version: 11.3.10
-    repository: https://charts.bitnami.com/bitnami
+  - name: kube-prometheus-stack
+    version: "83.5.1"
+    repository: https://prometheus-community.github.io/helm-charts
     condition: monitoring.enabled

--- a/chart/infra-server/monitoring-values.yaml
+++ b/chart/infra-server/monitoring-values.yaml
@@ -1,6 +1,9 @@
 kube-prometheus-stack:
   namespaceOverride: monitoring
 
+  grafana:
+    enabled: false
+
   defaultRules:
     rules:
       kubeApiserverAvailability: false

--- a/chart/infra-server/monitoring-values.yaml
+++ b/chart/infra-server/monitoring-values.yaml
@@ -1,8 +1,26 @@
-kube-prometheus:
+kube-prometheus-stack:
   namespaceOverride: monitoring
-  operator:
-    image:
-      repository: bitnamilegacy/prometheus-operator
+
+  defaultRules:
+    rules:
+      kubeApiserverAvailability: false
+      kubeApiserverBurnrate: false
+      kubeApiserverHistogram: false
+      kubeApiserverSlos: false
+      kubeControllerManager: false
+      kubelet: false
+      kubeProxy: false
+      kubeSchedulerAlerting: false
+      kubeSchedulerRecording: false
+      kubeStateMetrics: false
+      # Disables kubernetes-system{,-apiserver,-kubelet} rules; the kubelet group
+      # still matched without kube-state-metrics scrape targets.
+      kubernetesSystem: false
+      node: false
+      nodeExporterAlerting: false
+      nodeExporterRecording: false
+
+  prometheusOperator:
     resources:
       limits:
         cpu: 100m
@@ -16,53 +34,60 @@ kube-prometheus:
       enabled: false
 
   prometheus:
-    image:
-      repository: bitnamilegacy/prometheus
-    persistence:
-      enabled: true
-    resources:
-      limits:
-        cpu: 100m
-        ephemeral-storage: 1Gi
-        memory: 256Mi
-      requests:
-        cpu: 100m
-        ephemeral-storage: 1Gi
-        memory: 256Mi
+    prometheusSpec:
+      resources:
+        limits:
+          cpu: 100m
+          ephemeral-storage: 1Gi
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          ephemeral-storage: 1Gi
+          memory: 256Mi
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 8Gi
 
-  exporters:
-    node-exporter:
-      enabled: false
-    kube-state-metrics:
-      enabled: false
+  kubeStateMetrics:
+    enabled: false
+
+  nodeExporter:
+    enabled: false
+
   kubelet:
     enabled: false
+
   kubeApiServer:
     enabled: false
+
   kubeControllerManager:
     enabled: false
+
   kubeScheduler:
     enabled: false
+
   coreDns:
     enabled: false
+
   kubeProxy:
     enabled: false
 
   alertmanager:
-    image:
-      repository: bitnamilegacy/alertmanager
-    resources:
-      limits:
-        cpu: 100m
-        ephemeral-storage: 1Gi
-        memory: 256Mi
-      requests:
-        cpu: 100m
-        ephemeral-storage: 1Gi
-        memory: 256Mi
-    configSelector:
-      matchLabels:
-        alertmanagerConfig: slack
-
-  blackboxExporter:
-    enabled: false
+    alertmanagerSpec:
+      resources:
+        limits:
+          cpu: 100m
+          ephemeral-storage: 1Gi
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          ephemeral-storage: 1Gi
+          memory: 256Mi
+      alertmanagerConfigSelector:
+        matchLabels:
+          alertmanagerConfig: slack

--- a/chart/infra-server/requirements.lock
+++ b/chart/infra-server/requirements.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: argo-workflows
   repository: https://argoproj.github.io/argo-helm
   version: 1.0.4
-- name: kube-prometheus
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.3.10
-digest: sha256:c1eecd7d0fe344ae55befc669d9eb0c81a7070ceafc8423f61ac62e34f797176
-generated: "2026-04-16T16:44:19.411515+02:00"
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 83.5.1
+digest: sha256:05ea1799669a3df05539afb08ae3a51695c7d17788e036de9c11bd6d35366520
+generated: "2026-04-17T08:53:30.722111+02:00"

--- a/scripts/deploy/helm.sh
+++ b/scripts/deploy/helm.sh
@@ -14,7 +14,7 @@ TEST_MODE="${TEST_MODE:-false}"
 # When NO_MONITORING is true, skip kube-prometheus-stack and chart monitoring resources.
 # monitoring.enabled is applied after --values - so merged secrets cannot re-enable it.
 HELM_MONITORING_FINAL_SET=()
-if [[ "${NO_MONITORING}" == "true" ]]; then
+if [[ "${NO_MONITORING:-false}" == "true" ]]; then
     HELM_MONITORING_FINAL_SET=(--set monitoring.enabled=false)
 fi
 

--- a/scripts/deploy/helm.sh
+++ b/scripts/deploy/helm.sh
@@ -11,7 +11,7 @@ SECRET_VERSION="${4:-latest}"
 # Cannot use CI, because then CD with GHA would not be possible.
 TEST_MODE="${TEST_MODE:-false}"
 
-# When NO_MONITORING is true, skip kube-prometheus and chart monitoring resources.
+# When NO_MONITORING is true, skip kube-prometheus-stack and chart monitoring resources.
 # monitoring.enabled is applied after --values - so merged secrets cannot re-enable it.
 HELM_MONITORING_FINAL_SET=()
 if [[ "${NO_MONITORING}" == "true" ]]; then


### PR DESCRIPTION
Replace Bitnami kube-prometheus with Prometheus Community kube-prometheus-stack (83.5.1), refresh requirements.lock, and rewrite monitoring-values.yaml for the new subchart: same resource limits, PVC-backed Prometheus, disabled node/kube-state/kube control-plane scrapers, Slack routing via alertmanagerConfigSelector, tuned defaultRules for disabled targets, no custom image repos, and Grafana off.

Why: Bitnami kube-prometheus chart is outdated and the legacy images were deleted from DockerHub. 

Also includes a fix for #1804 if `NO_MONITORING` is unset. 

I tested the monitoring stack in a separate GKE cluster and it produced a test alert in Slack: https://redhat-internal.slack.com/archives/C06L0LDBEGZ/p1776413056761179