### PR TITLE
ROX-34341: use rotated ARO cluster manager credentials without funky overrides

### DIFF
--- a/chart/infra-server/static/workflow-openshift-aro.yaml
+++ b/chart/infra-server/static/workflow-openshift-aro.yaml
@@ -49,26 +49,26 @@ spec:
           - create
           - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'
         env:
-          - name: AZURE_SUBSCRIPTION_ID
-            valueFrom:
-              secretKeyRef:
-                name: aro-cluster-manager
-                key: AZURE_SUBSCRIPTION_ID
-          - name: AZURE_SP_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: aro-cluster-manager
-                key: AZURE_SP_CLIENT_ID
           - name: AZURE_SP_TENANT_ID
             valueFrom:
               secretKeyRef:
                 name: aro-cluster-manager
                 key: AZURE_SP_TENANT_ID
-          - name: AZURE_SP_SECRET_VAL
+          - name: AZURE_SP_ARO_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: aro-cluster-manager
-                key: AZURE_SP_SECRET_VAL
+                key: AZURE_SP_ARO_PASSWORD
+          - name: AZURE_SP_ARO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: aro-cluster-manager
+                key: AZURE_SP_ARO_USERNAME
+          - name: AZURE_SUBSCRIPTION_ID
+            valueFrom:
+              secretKeyRef:
+                name: aro-cluster-manager
+                key: AZURE_SUBSCRIPTION_ID
           - name: REDHAT_PULL_SECRET_BASE64
             valueFrom:
               secretKeyRef:
@@ -138,26 +138,26 @@ spec:
           - destroy
           - '{{ "{{" }}workflow.parameters.name{{ "}}" }}'
         env:
-          - name: AZURE_SUBSCRIPTION_ID
-            valueFrom:
-              secretKeyRef:
-                name: aro-cluster-manager
-                key: AZURE_SUBSCRIPTION_ID
-          - name: AZURE_SP_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: aro-cluster-manager
-                key: AZURE_SP_CLIENT_ID
           - name: AZURE_SP_TENANT_ID
             valueFrom:
               secretKeyRef:
                 name: aro-cluster-manager
                 key: AZURE_SP_TENANT_ID
-          - name: AZURE_SP_SECRET_VAL
+          - name: AZURE_SP_ARO_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: aro-cluster-manager
-                key: AZURE_SP_SECRET_VAL
+                key: AZURE_SP_ARO_PASSWORD
+          - name: AZURE_SP_ARO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: aro-cluster-manager
+                key: AZURE_SP_ARO_USERNAME
+          - name: AZURE_SUBSCRIPTION_ID
+            valueFrom:
+              secretKeyRef:
+                name: aro-cluster-manager
+                key: AZURE_SUBSCRIPTION_ID
           - name: REDHAT_PULL_SECRET_BASE64
             valueFrom:
               secretKeyRef:

--- a/chart/infra-server/templates/aro/secrets.yaml
+++ b/chart/infra-server/templates/aro/secrets.yaml
@@ -6,13 +6,13 @@ metadata:
   name: aro-cluster-manager
   namespace: default
 data:
-  AZURE_SUBSCRIPTION_ID: |-
-    {{ .Values.aroClusterManager.azureSubscriptionId | b64enc }}
-  AZURE_SP_CLIENT_ID: |-
+  AZURE_SP_ARO_PASSWORD: |-
+    {{ .Values.aroClusterManager.azureSPSecretVal | b64enc }}
+  AZURE_SP_ARO_USERNAME: |-
     {{ .Values.aroClusterManager.azureSPClientId | b64enc }}
   AZURE_SP_TENANT_ID: |-
     {{ .Values.aroClusterManager.azureSPTenantId | b64enc }}
-  AZURE_SP_SECRET_VAL: |-
-    {{ .Values.aroClusterManager.azureSPSecretVal | b64enc }}
+  AZURE_SUBSCRIPTION_ID: |-
+    {{ .Values.aroClusterManager.azureSubscriptionId | b64enc }}
   REDHAT_PULL_SECRET_BASE64: |-
     {{ .Values.aroClusterManager.redHatPullSecretBase64 | b64enc }}


### PR DESCRIPTION
Actually use the overrides from https://github.com/stackrox/automation-flavors/pull/342/changes#diff-83539fe9d856648378506646e58ea2576036ea399a6b84806e08733350072cddL235-L237