### PR TITLE
feat(osd): Add enable-wif parameter for OSD GCP clusters

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -979,6 +979,11 @@
       value: us-east1
       kind: optional
 
+    - name: enable-wif
+      description: Use Workload Identity Federation instead of service account key
+      value: "false"
+      kind: optional
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -44,7 +44,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.13.0
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-{{ .Chart.Annotations.automationFlavorsVersion }}
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -130,7 +130,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.13.0
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-{{ .Chart.Annotations.automationFlavorsVersion }}
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -14,6 +14,8 @@ spec:
         value: "m5.xlarge"
       - name: gcp-region
         value: us-east1
+      - name: enable-wif
+        value: "false"
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -42,7 +44,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-{{ .Chart.Annotations.automationFlavorsVersion }}
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.12.12-44-g11e818615a-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -76,6 +78,8 @@ spec:
             value: "infra"
           - name: GCP_REGION
             value: '{{ "{{" }}workflow.parameters.gcp-region{{ "}}" }}'
+          - name: ENABLE_WIF
+            value: '{{ "{{" }}workflow.parameters.enable-wif{{ "}}" }}'
         volumeMounts:
           - name: data
             mountPath: /data
@@ -126,7 +130,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-{{ .Chart.Annotations.automationFlavorsVersion }}
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.12.12-44-g11e818615a-snapshot
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -152,6 +156,8 @@ spec:
                 key: GCP_SERVICE_ACCOUNT_KEY_BASE64
           - name: GCP_PROJECT
             value: "acs-team-temp-dev"
+          - name: ENABLE_WIF
+            value: '{{ "{{" }}workflow.parameters.enable-wif{{ "}}" }}'
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-osd-gcp.yaml
+++ b/chart/infra-server/static/workflow-osd-gcp.yaml
@@ -44,7 +44,7 @@ spec:
     - name: create
       activeDeadlineSeconds: 7200
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.12.12-44-g11e818615a-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.13.0
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh
@@ -130,7 +130,7 @@ spec:
     - name: destroy
       activeDeadlineSeconds: 3600
       container:
-        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.12.12-44-g11e818615a-snapshot
+        image: quay.io/stackrox-io/ci:automation-flavors-osd-0.13.0
         imagePullPolicy: Always
         command:
           - ./entrypoint.sh


### PR DESCRIPTION
## Summary

Add optional `enable-wif` parameter to the OSD on GCP flavor, allowing users to create clusters using Workload Identity Federation instead of long-lived service account keys.

- Adds `enable-wif` parameter (default: `false`) to flavor definition
- Passes `ENABLE_WIF` env var to both create and destroy workflow containers
- Uses released `automation-flavors-osd-0.13.0` image with WIF support

## Tested

Created a WIF-enabled OSD GCP cluster (`dh-05-19-3`) via the dev infra server with `enable-wif=true`. Cluster provisioned successfully with WIF (federated credentials, no static SA keys). RHACS was deployed and GCP integrations (GCR, GAR, GCS) verified working with WIF.

## Prerequisites

The `osd-ccs-admin` service account in `acs-team-temp-dev` required additional IAM roles for WIF config creation: `roles/iam.roleAdmin`, `roles/browser`. These have been added manually; TODO: codify in automation-iac.

Depends on: https://github.com/stackrox/automation-flavors/pull/341 (merged as 0.13.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
