### PR TITLE
feat: support ocp capabilities

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.10.2
-  automationFlavorsVersion: 0.13.0
+  automationFlavorsVersion: 0.14.0
   ocpCredentialsMode: Passthrough
 dependencies:
   - name: argo-workflows

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -314,6 +314,21 @@
       value: true
       kind: optional
 
+    - name: baseline-capability-set
+      description: Baseline capability set
+      value: "vCurrent"
+      kind: optional
+      help: |
+        Defines a baseline set of capabilities to install. Valid values are `None`, `vCurrent` and `v4.x`. If you select `None`, all optional capabilities are disabled. The default value is `vCurrent`, which enables all optional capabilities.
+
+    - name: additional-enabled-capabilities
+      description: Additional capabilities to enable
+      value: ""
+      kind: optional
+      help: |
+        Defines a list of capabilities to explicitly enable. These capabilities are enabled in addition to the capabilities specified in the baseline capability set.
+        Example: `["DeploymentConfig", "ImageRegistry"]`
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -465,6 +480,21 @@
       value: true
       kind: optional
 
+    - name: baseline-capability-set
+      description: Baseline capability set
+      value: "vCurrent"
+      kind: optional
+      help: |
+        Defines a baseline set of capabilities to install. Valid values are `None`, `vCurrent` and `v4.x`. If you select `None`, all optional capabilities are disabled. The default value is `vCurrent`, which enables all optional capabilities.
+
+    - name: additional-enabled-capabilities
+      description: Additional capabilities to enable
+      value: ""
+      kind: optional
+      help: |
+        Defines a list of capabilities to explicitly enable. These capabilities are enabled in addition to the capabilities specified in the baseline capability set.
+        Example: `["DeploymentConfig", "ImageRegistry"]`
+
   artifacts:
     - name: admin-password
       description: Admin password for StackRox console
@@ -605,6 +635,21 @@
       description: Ensure an SSD StorageClass is the default StorageClass for the cluster
       value: true
       kind: optional
+
+    - name: baseline-capability-set
+      description: Baseline capability set
+      value: "vCurrent"
+      kind: optional
+      help: |
+        Defines a baseline set of capabilities to install. Valid values are `None`, `vCurrent` and `v4.x`. If you select `None`, all optional capabilities are disabled. The default value is `vCurrent`, which enables all optional capabilities.
+
+    - name: additional-enabled-capabilities
+      description: Additional capabilities to enable
+      value: ""
+      kind: optional
+      help: |
+        Defines a list of capabilities to explicitly enable. These capabilities are enabled in addition to the capabilities specified in the baseline capability set.
+        Example: `["DeploymentConfig", "ImageRegistry"]`
 
   artifacts:
     - name: kubeconfig

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -22,6 +22,10 @@ spec:
       - name: credentials-mode
       - name: region
       - name: ssd-storage-class
+      - name: baseline-capability-set
+        value: "vCurrent"
+      - name: additional-enabled-capabilities
+        value: ""
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -124,6 +128,10 @@ spec:
             value: '{{ "{{" }}workflow.parameters.credentials-mode{{ "}}" }}'
           - name: SSD_STORAGE_CLASS
             value: '{{ "{{" }}workflow.parameters.ssd-storage-class{{ "}}" }}'
+          - name: BASELINE_CAPABILITY_SET
+            value: '{{ "{{" }}workflow.parameters.baseline-capability-set{{ "}}" }}'
+          - name: ADDITIONAL_ENABLED_CAPABILITIES
+            value: '{{ "{{" }}workflow.parameters.additional-enabled-capabilities{{ "}}" }}'
 
     - name: pre-install
       script:

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -28,6 +28,10 @@ spec:
       - name: credentials-mode
       - name: keep-failed-cluster
       - name: ssd-storage-class
+      - name: baseline-capability-set
+        value: "vCurrent"
+      - name: additional-enabled-capabilities
+        value: ""
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -143,6 +147,10 @@ spec:
             value: '{{ "{{" }}workflow.parameters.keep-failed-cluster{{ "}}" }}'
           - name: SSD_STORAGE_CLASS
             value: '{{ "{{" }}workflow.parameters.ssd-storage-class{{ "}}" }}'
+          - name: BASELINE_CAPABILITY_SET
+            value: '{{ "{{" }}workflow.parameters.baseline-capability-set{{ "}}" }}'
+          - name: ADDITIONAL_ENABLED_CAPABILITIES
+            value: '{{ "{{" }}workflow.parameters.additional-enabled-capabilities{{ "}}" }}'
         volumeMounts:
           - name: data
             mountPath: /data


### PR DESCRIPTION
Allow disabling optional cluster capabilities (e.g. DeploymentConfig) via BASELINE_CAPABILITY_SET and ADDITIONAL_ENABLED_CAPABILITIES env vars. The purpose of customizing the capabilities is reproducing bespoke customer environments, which can be helpful for testing or trouble shooting.

<img width="564" height="803" alt="SCR-20260602-mohd" src="https://github.com/user-attachments/assets/5baa2792-098b-473a-b2db-f4a0f4cf732f" />

<img width="621" height="803" alt="SCR-20260602-moiv" src="https://github.com/user-attachments/assets/0a843865-b566-44d4-af1d-a985f0fabfe8" />