### PR TITLE
ROX-35000: Add optional OpenShift Virtualization support to openshift-4 flavor

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -334,9 +334,13 @@
       value: false
       kind: optional
       help: |
-        When true, an additional n2-standard-8 worker node is added and configured
-        with OpenShift Virtualization (KubeVirt) including VSOCK support. A single
-        VM is created using the OS specified by the vm-os parameter.
+        When true, an extra worker node is added by scaling up an existing
+        MachineSet and configured with OpenShift Virtualization (KubeVirt)
+        including VSOCK support. A single VM is created using the OS
+        specified by the vm-os parameter.
+        For best VM performance, use n2 worker nodes
+        (worker-node-type=n2-standard-8). On e2 instances, KVM emulation
+        is used as a fallback (slower).
 
     - name: vm-os
       description: OS for the virtual machine (rhel9, rhel10)
@@ -688,9 +692,13 @@
       value: false
       kind: optional
       help: |
-        When true, an additional n2-standard-8 worker node is added and configured
-        with OpenShift Virtualization (KubeVirt) including VSOCK support. A single
-        VM is created using the OS specified by the vm-os parameter.
+        When true, an extra worker node is added by scaling up an existing
+        MachineSet and configured with OpenShift Virtualization (KubeVirt)
+        including VSOCK support. A single VM is created using the OS
+        specified by the vm-os parameter.
+        For best VM performance, use n2 worker nodes
+        (worker-node-type=n2-standard-8). On e2 instances, KVM emulation
+        is used as a fallback (slower).
 
     - name: vm-os
       description: OS for the virtual machine (rhel9, rhel10)

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -329,6 +329,35 @@
         Defines a list of capabilities to explicitly enable. These capabilities are enabled in addition to the capabilities specified in the baseline capability set.
         Example: `["DeploymentConfig", "ImageRegistry"]`
 
+    - name: install-virt
+      description: Install OpenShift Virtualization operator with VSOCK and create a VM
+      value: false
+      kind: optional
+      help: |
+        When true, an additional n2-standard-8 worker node is added and configured
+        with OpenShift Virtualization (KubeVirt) including VSOCK support. A single
+        VM is created using the OS specified by the vm-os parameter.
+
+    - name: vm-os
+      description: OS for the virtual machine (rhel9, rhel10)
+      value: rhel9
+      kind: optional
+      help: |
+        The RHEL version for the virtual machine container disk.
+        Valid values: rhel9, rhel10.
+        The image used will be quay.io/rhacs-eng/vm-images:<vm-os>-dnf-primed-latest.
+
+    - name: virt-node-dedicated
+      description: Taint the virt node so only VMs are scheduled on it
+      value: false
+      kind: optional
+      help: |
+        When true, the dedicated virt worker node is tainted with
+        node-role.kubernetes.io/virt:NoSchedule so that only VM workloads
+        (which have a matching toleration) are scheduled on it.
+        When false, the virt node also accepts regular ACS/OCP workloads.
+        Only relevant when install-virt is true.
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -358,6 +387,9 @@
 
     - name: cluster-console-password
       description: The password to login at the openshift console
+
+    - name: vm-access
+      description: Credentials and access commands for the created VM
 
 ######################
 #  openshift-4-demo  #
@@ -651,6 +683,35 @@
         Defines a list of capabilities to explicitly enable. These capabilities are enabled in addition to the capabilities specified in the baseline capability set.
         Example: `["DeploymentConfig", "ImageRegistry"]`
 
+    - name: install-virt
+      description: Install OpenShift Virtualization operator with VSOCK and create a VM
+      value: false
+      kind: optional
+      help: |
+        When true, an additional n2-standard-8 worker node is added and configured
+        with OpenShift Virtualization (KubeVirt) including VSOCK support. A single
+        VM is created using the OS specified by the vm-os parameter.
+
+    - name: vm-os
+      description: OS for the virtual machine (rhel9, rhel10)
+      value: rhel9
+      kind: optional
+      help: |
+        The RHEL version for the virtual machine container disk.
+        Valid values: rhel9, rhel10.
+        The image used will be quay.io/rhacs-eng/vm-images:<vm-os>-dnf-primed-latest.
+
+    - name: virt-node-dedicated
+      description: Taint the virt node so only VMs are scheduled on it
+      value: false
+      kind: optional
+      help: |
+        When true, the dedicated virt worker node is tainted with
+        node-role.kubernetes.io/virt:NoSchedule so that only VM workloads
+        (which have a matching toleration) are scheduled on it.
+        When false, the virt node also accepts regular ACS/OCP workloads.
+        Only relevant when install-virt is true.
+
   artifacts:
     - name: kubeconfig
       description: Kube config for connecting to this cluster
@@ -680,6 +741,9 @@
 
     - name: cluster-console-password
       description: The password to login at the openshift console
+
+    - name: vm-access
+      description: Credentials and access commands for the created VM
 
 #####################
 #  AWS EKS          #

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -275,7 +275,7 @@ spec:
           timeout=600
           elapsed=0
           while true; do
-            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Ready")].status=="True")].metadata.name}' 2>/dev/null || echo "")
+            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | jq -r '[.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True")) | .metadata.name] | join(" ")' 2>/dev/null || echo "")
             if [ -n "$READY_NODES" ]; then
               echo "Virt node is Ready: $READY_NODES"
               break
@@ -516,10 +516,6 @@ spec:
           if oc get vm "$VM_NAME" -n "$NAMESPACE" &>/dev/null; then
             STATUS=$(oc get vm "$VM_NAME" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
             echo "VM $VM_NAME already exists (status: $STATUS)"
-            if [ "$STATUS" = "Running" ]; then
-              echo "VM is already running"
-              exit 0
-            fi
           fi
 
           # Build node placement YAML fragment conditionally

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -228,163 +228,66 @@ spec:
             exit 0
           fi
 
-          WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json 2>/dev/null | jq -r '
-            .items
-            | map(select(
-                .metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker" or
-                .metadata.labels["machine.openshift.io/cluster-api-machine-type"] == "worker"
-              ))
-            | sort_by(.metadata.name)
-            | .[0].metadata.name // empty
-          ' 2>/dev/null || echo "")
-
-          CREATED_VIA=""
-
-          if [ -n "$WORKER_MS" ]; then
-            # ── Legacy path: clone MachineSet in openshift-machine-api ──
-            echo "Using legacy MachineSet path (source: $WORKER_MS)"
-            ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api \
-              -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
-            VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
-            CREATED_VIA="legacy"
-
-            if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
-              echo "MachineSet $VIRT_MS_NAME already exists"
-            else
-              JQ_FILTER='
-                del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
-                .metadata.name = $name |
-                .spec.replicas = 1 |
-                .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
-                .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
-                .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
-                .spec.template.spec.providerSpec.value.machineType = $machineType |
-                .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
-              '
-              if [ "$DEDICATED" = "true" ]; then
-                JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
-              fi
-
-              oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
-                jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
-                oc apply -f -
-              echo "Created MachineSet $VIRT_MS_NAME"
+          # On OCP 4.19+, the installer uses CAPI via a local envtest to provision
+          # machines, but the running cluster uses legacy machine.openshift.io
+          # MachineSets. The Machine API operator may need time after cluster creation
+          # to reconcile MachineSets, so we retry instead of failing immediately.
+          echo "Waiting for worker MachineSets in openshift-machine-api..."
+          ms_timeout=300
+          ms_elapsed=0
+          WORKER_MS=""
+          while [ -z "$WORKER_MS" ]; do
+            WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json 2>/dev/null | jq -r '
+              .items
+              | map(select(
+                  .metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker" or
+                  .metadata.labels["machine.openshift.io/cluster-api-machine-type"] == "worker"
+                ))
+              | sort_by(.metadata.name)
+              | .[0].metadata.name // empty
+            ' 2>/dev/null || echo "")
+            if [ -n "$WORKER_MS" ]; then
+              break
             fi
+            if [ $ms_elapsed -ge $ms_timeout ]; then
+              echo "ERROR: No worker MachineSet found in openshift-machine-api after ${ms_timeout}s"
+              oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null || true
+              oc get machines -n openshift-machine-api --no-headers 2>/dev/null || true
+              exit 1
+            fi
+            if [ $((ms_elapsed % 30)) -eq 0 ]; then
+              echo "No worker MachineSets yet, retrying... (${ms_elapsed}s)"
+            fi
+            sleep 15
+            ms_elapsed=$((ms_elapsed + 15))
+          done
+          echo "Using $WORKER_MS as template"
 
+          ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api \
+            -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
+          VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
+
+          if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
+            echo "MachineSet $VIRT_MS_NAME already exists"
           else
-            # ── CAPI path: GCPMachineTemplate + MachineSet in openshift-cluster-api-guests ──
-            echo "No legacy MachineSets found, using Cluster API path"
-            CAPI_NS="openshift-cluster-api-guests"
-            CREATED_VIA="capi"
-
-            CLUSTER_NAME=$(oc get clusters.cluster.x-k8s.io -n "$CAPI_NS" \
-              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-            if [ -z "$CLUSTER_NAME" ]; then
-              echo "ERROR: No CAPI Cluster found in $CAPI_NS"
-              echo "Neither legacy MachineSets nor CAPI resources are available"
-              exit 1
-            fi
-            echo "CAPI Cluster: $CLUSTER_NAME"
-
-            WORKER_GCP_MACHINE=$(oc get gcpmachines.infrastructure.cluster.x-k8s.io \
-              -n "$CAPI_NS" -o json | jq -r '
-              [.items[] | select(.metadata.name | test("worker"))]
-              | sort_by(.metadata.name)
-              | .[0].metadata.name // empty
-            ')
-            if [ -z "$WORKER_GCP_MACHINE" ]; then
-              echo "ERROR: No worker GCPMachine found in $CAPI_NS"
-              oc get gcpmachines.infrastructure.cluster.x-k8s.io -n "$CAPI_NS" \
-                --no-headers 2>/dev/null || true
-              exit 1
-            fi
-            echo "Source GCPMachine: $WORKER_GCP_MACHINE"
-
-            GCP_SPEC=$(oc get gcpmachines.infrastructure.cluster.x-k8s.io \
-              "$WORKER_GCP_MACHINE" -n "$CAPI_NS" -o json | jq '.spec')
-            ZONE=$(echo "$GCP_SPEC" | jq -r '.zone // .failureDomain // empty')
-            echo "Zone: $ZONE"
-
-            VIRT_TEMPLATE_NAME="${INFRA_ID}-virt-worker"
-            VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE:-a}"
-
-            WORKER_MACHINE=$(oc get machines.cluster.x-k8s.io -n "$CAPI_NS" -o json | jq -r '
-              [.items[] | select(.metadata.name | test("worker"))]
-              | sort_by(.metadata.name)
-              | .[0].metadata.name // empty
-            ')
-            BOOTSTRAP_SECRET=$(oc get machines.cluster.x-k8s.io "$WORKER_MACHINE" \
-              -n "$CAPI_NS" -o jsonpath='{.spec.bootstrap.dataSecretName}' 2>/dev/null || echo "")
-            if [ -z "$BOOTSTRAP_SECRET" ]; then
-              BOOTSTRAP_SECRET="${INFRA_ID}-worker"
-              echo "Bootstrap secret not found on Machine, using convention: $BOOTSTRAP_SECRET"
-            else
-              echo "Bootstrap secret: $BOOTSTRAP_SECRET"
+            JQ_FILTER='
+              del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
+              .metadata.name = $name |
+              .spec.replicas = 1 |
+              .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
+              .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
+              .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
+              .spec.template.spec.providerSpec.value.machineType = $machineType |
+              .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
+            '
+            if [ "$DEDICATED" = "true" ]; then
+              JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
             fi
 
-            if oc get machinesets.cluster.x-k8s.io "$VIRT_MS_NAME" -n "$CAPI_NS" &>/dev/null; then
-              echo "CAPI MachineSet $VIRT_MS_NAME already exists"
-            else
-              echo "$GCP_SPEC" | jq \
-                --arg name "$VIRT_TEMPLATE_NAME" --arg ns "$CAPI_NS" '{
-                apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-                kind: "GCPMachineTemplate",
-                metadata: { name: $name, namespace: $ns },
-                spec: { template: { spec: (. | del(.providerID, .providerStatus) |
-                  if has("instanceType") then .instanceType = "n2-standard-8"
-                  elif has("machineType") then .machineType = "n2-standard-8"
-                  else . + {instanceType: "n2-standard-8"}
-                  end
-                )}}
-              }' | oc apply -f -
-              echo "Created GCPMachineTemplate $VIRT_TEMPLATE_NAME"
-
-              jq -n \
-                --arg name "$VIRT_MS_NAME" \
-                --arg ns "$CAPI_NS" \
-                --arg cluster "$CLUSTER_NAME" \
-                --arg tmpl "$VIRT_TEMPLATE_NAME" \
-                --arg boot "$BOOTSTRAP_SECRET" \
-              '{
-                apiVersion: "cluster.x-k8s.io/v1beta1",
-                kind: "MachineSet",
-                metadata: {
-                  name: $name,
-                  namespace: $ns,
-                  labels: { "cluster.x-k8s.io/cluster-name": $cluster }
-                },
-                spec: {
-                  clusterName: $cluster,
-                  replicas: 1,
-                  selector: {
-                    matchLabels: {
-                      "cluster.x-k8s.io/cluster-name": $cluster,
-                      "cluster.x-k8s.io/set-name": $name
-                    }
-                  },
-                  template: {
-                    metadata: {
-                      labels: {
-                        "cluster.x-k8s.io/cluster-name": $cluster,
-                        "cluster.x-k8s.io/set-name": $name,
-                        "node-role.kubernetes.io/worker": "",
-                        "node-role.kubernetes.io/virt": ""
-                      }
-                    },
-                    spec: {
-                      clusterName: $cluster,
-                      bootstrap: { dataSecretName: $boot },
-                      infrastructureRef: {
-                        apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-                        kind: "GCPMachineTemplate",
-                        name: $tmpl
-                      }
-                    }
-                  }
-                }
-              }' | oc apply -f -
-              echo "Created CAPI MachineSet $VIRT_MS_NAME"
-            fi
+            oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
+              jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
+              oc apply -f -
+            echo "Created MachineSet $VIRT_MS_NAME"
           fi
 
           echo "Waiting for virt node to become Ready..."
@@ -399,58 +302,22 @@ spec:
               echo "Virt node is Ready: $READY_NODES"
               break
             fi
-
-            if [ "$CREATED_VIA" = "capi" ] && [ $elapsed -ge 120 ]; then
-              CAPI_NODE=$(oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
-                -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
-                -o jsonpath='{.items[0].status.nodeRef.name}' 2>/dev/null || echo "")
-              if [ -n "$CAPI_NODE" ]; then
-                NODE_READY=$(oc get node "$CAPI_NODE" \
-                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-                if [ "$NODE_READY" = "True" ]; then
-                  echo "CAPI node $CAPI_NODE is Ready, applying virt label"
-                  oc label node "$CAPI_NODE" node-role.kubernetes.io/virt= --overwrite
-                  READY_NODES="$CAPI_NODE"
-                  break
-                fi
-              fi
-            fi
-
             if [ $elapsed -ge $timeout ]; then
               echo "ERROR: Timeout waiting for virt node after ${timeout}s"
-              if [ "$CREATED_VIA" = "legacy" ]; then
-                oc get machines -n openshift-machine-api \
-                  -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
-                  --no-headers 2>/dev/null || true
-              else
-                oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
-                  -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
-                  --no-headers 2>/dev/null || true
-              fi
+              oc get machines -n openshift-machine-api \
+                -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
+                --no-headers 2>/dev/null || true
               exit 1
             fi
             if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
               echo "Still waiting... (${elapsed}s elapsed)"
-              if [ "$CREATED_VIA" = "legacy" ]; then
-                oc get machines -n openshift-machine-api \
-                  -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
-                  --no-headers 2>/dev/null || true
-              else
-                oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
-                  -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
-                  --no-headers 2>/dev/null || true
-              fi
+              oc get machines -n openshift-machine-api \
+                -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
+                --no-headers 2>/dev/null || true
             fi
             sleep 15
             elapsed=$((elapsed + 15))
           done
-
-          if [ "$DEDICATED" = "true" ] && [ "$CREATED_VIA" = "capi" ]; then
-            VIRT_NODE=$(echo "$READY_NODES" | awk '{print $1}')
-            echo "Applying NoSchedule taint to $VIRT_NODE (CAPI path)"
-            oc adm taint nodes "$VIRT_NODE" \
-              node-role.kubernetes.io/virt=:NoSchedule --overwrite
-          fi
 
           echo "=== Virt worker node ready ==="
         volumeMounts:

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -214,12 +214,11 @@ spec:
           export KUBECONFIG=/data/auth/kubeconfig
 
           DEDICATED='{{ "{{" }}workflow.parameters.virt-node-dedicated{{ "}}" }}'
-          INFRA_ID=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
 
-          echo "=== Creating dedicated virt worker node ==="
+          echo "=== Adding virt worker node ==="
           echo "Dedicated (tainted) mode: $DEDICATED"
-          echo "Infrastructure ID: $INFRA_ID"
 
+          # Idempotency: skip if a virt-labeled node already exists and is Ready
           READY_VIRT=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | \
             jq '[.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length' || echo "0")
           if [ "${READY_VIRT:-0}" -gt 0 ]; then
@@ -228,98 +227,70 @@ spec:
             exit 0
           fi
 
-          # On OCP 4.19+, the installer uses CAPI via a local envtest to provision
-          # machines, but the running cluster uses legacy machine.openshift.io
-          # MachineSets. The Machine API operator may need time after cluster creation
-          # to reconcile MachineSets, so we retry instead of failing immediately.
-          echo "Waiting for worker MachineSets in openshift-machine-api..."
-          ms_timeout=300
-          ms_elapsed=0
-          WORKER_MS=""
-          while [ -z "$WORKER_MS" ]; do
-            WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json 2>/dev/null | jq -r '
-              .items
-              | map(select(
-                  .metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker" or
-                  .metadata.labels["machine.openshift.io/cluster-api-machine-type"] == "worker"
-                ))
-              | sort_by(.metadata.name)
-              | .[0].metadata.name // empty
-            ' 2>/dev/null || echo "")
-            if [ -n "$WORKER_MS" ]; then
-              break
-            fi
-            if [ $ms_elapsed -ge $ms_timeout ]; then
-              echo "ERROR: No worker MachineSet found in openshift-machine-api after ${ms_timeout}s"
-              oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null || true
-              oc get machines -n openshift-machine-api --no-headers 2>/dev/null || true
-              exit 1
-            fi
-            if [ $((ms_elapsed % 30)) -eq 0 ]; then
-              echo "No worker MachineSets yet, retrying... (${ms_elapsed}s)"
-            fi
-            sleep 15
-            ms_elapsed=$((ms_elapsed + 15))
-          done
-          echo "Using $WORKER_MS as template"
+          # Snapshot existing worker node names before scaling
+          EXISTING_NODES=$(oc get nodes -l node-role.kubernetes.io/worker \
+            -o jsonpath='{.items[*].metadata.name}')
+          echo "Existing worker nodes: $EXISTING_NODES"
 
-          ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api \
-            -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
-          VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
-
-          if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
-            echo "MachineSet $VIRT_MS_NAME already exists"
-          else
-            JQ_FILTER='
-              del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
-              .metadata.name = $name |
-              .spec.replicas = 1 |
-              .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
-              .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
-              .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
-              .spec.template.spec.providerSpec.value.machineType = $machineType |
-              .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
-            '
-            if [ "$DEDICATED" = "true" ]; then
-              JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
-            fi
-
-            oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
-              jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
-              oc apply -f -
-            echo "Created MachineSet $VIRT_MS_NAME"
+          # Pick the first worker MachineSet (by name) and scale it up by 1
+          WORKER_MS=$(oc get machinesets -n openshift-machine-api \
+            -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$WORKER_MS" ]; then
+            echo "ERROR: No MachineSets found in openshift-machine-api"
+            oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null || true
+            exit 1
           fi
 
-          echo "Waiting for virt node to become Ready..."
+          CURRENT_REPLICAS=$(oc get machineset "$WORKER_MS" -n openshift-machine-api \
+            -o jsonpath='{.spec.replicas}')
+          NEW_REPLICAS=$((CURRENT_REPLICAS + 1))
+          echo "Scaling MachineSet $WORKER_MS from $CURRENT_REPLICAS to $NEW_REPLICAS"
+          oc scale machineset "$WORKER_MS" -n openshift-machine-api \
+            --replicas="$NEW_REPLICAS"
+
+          # Wait for the new node to join and become Ready
+          echo "Waiting for new worker node to become Ready..."
           timeout=600
           elapsed=0
+          NEW_NODE=""
           while true; do
-            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | \
+            ALL_READY=$(oc get nodes -l node-role.kubernetes.io/worker -o json 2>/dev/null | \
               jq -r '[.items[] | select(.status.conditions[]? |
                 select(.type=="Ready" and .status=="True")) |
-                .metadata.name] | join(" ")' 2>/dev/null || echo "")
-            if [ -n "$READY_NODES" ]; then
-              echo "Virt node is Ready: $READY_NODES"
-              break
-            fi
+                .metadata.name] | .[]' 2>/dev/null || echo "")
+            for node in $ALL_READY; do
+              if ! echo "$EXISTING_NODES" | grep -qw "$node"; then
+                NEW_NODE="$node"
+                break 2
+              fi
+            done
             if [ $elapsed -ge $timeout ]; then
-              echo "ERROR: Timeout waiting for virt node after ${timeout}s"
-              oc get machines -n openshift-machine-api \
-                -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
-                --no-headers 2>/dev/null || true
+              echo "ERROR: Timeout waiting for new node after ${timeout}s"
+              oc get machines -n openshift-machine-api --no-headers 2>/dev/null || true
               exit 1
             fi
             if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
               echo "Still waiting... (${elapsed}s elapsed)"
-              oc get machines -n openshift-machine-api \
-                -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
-                --no-headers 2>/dev/null || true
+              oc get nodes -l node-role.kubernetes.io/worker --no-headers 2>/dev/null || true
             fi
             sleep 15
             elapsed=$((elapsed + 15))
           done
 
-          echo "=== Virt worker node ready ==="
+          echo "New node: $NEW_NODE"
+
+          # Label the new node for virt workloads
+          oc label node "$NEW_NODE" node-role.kubernetes.io/virt= --overwrite
+          echo "Labeled $NEW_NODE with node-role.kubernetes.io/virt"
+
+          # Optionally taint so only VM workloads run on it
+          if [ "$DEDICATED" = "true" ]; then
+            oc adm taint nodes "$NEW_NODE" \
+              node-role.kubernetes.io/virt=:NoSchedule --overwrite
+            echo "Tainted $NEW_NODE with NoSchedule"
+          fi
+
+          echo "=== Virt worker node ready: $NEW_NODE ==="
         volumeMounts:
           - name: data
             mountPath: /data

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -649,9 +649,20 @@ spec:
               ;;
           esac
 
-          VM_PASSWORD=$(openssl rand -hex 10)
-
           echo "=== Creating VM: $VM_NAME (OS: $VM_OS, dedicated=$DEDICATED) ==="
+
+          # Check if VM already exists — skip creation to avoid publishing stale credentials
+          if oc get vm "$VM_NAME" -n "$NAMESPACE" &>/dev/null; then
+            STATUS=$(oc get vm "$VM_NAME" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
+            echo "VM $VM_NAME already exists (status: $STATUS), skipping creation"
+            echo "# VM Access Information (pre-existing VM)" > /data/vm-access.md
+            echo "" >> /data/vm-access.md
+            echo "VM was already provisioned in a prior run. Password was set at first boot." >> /data/vm-access.md
+            echo "Check cluster secrets or prior workflow artifacts for credentials." >> /data/vm-access.md
+            exit 0
+          fi
+
+          VM_PASSWORD=$(openssl rand -hex 10)
 
           # Copy the already-provisioned Quay pull secret from the infra namespace into the target cluster
           echo "Creating pull secret for quay.io/rhacs-eng in namespace $NAMESPACE from mounted infra secret..."
@@ -670,12 +681,6 @@ spec:
             .dockerconfigjson: $(base64 < /infra-secrets/quay/.dockerconfigjson | tr -d '\n')
           EOFSECRET
           echo "Pull secret created"
-
-          # Check if VM already exists
-          if oc get vm "$VM_NAME" -n "$NAMESPACE" &>/dev/null; then
-            STATUS=$(oc get vm "$VM_NAME" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
-            echo "VM $VM_NAME already exists (status: $STATUS)"
-          fi
 
           # Build node placement YAML fragment conditionally
           NODE_PLACEMENT=""
@@ -758,9 +763,12 @@ spec:
               break
             fi
             if [ $elapsed -ge $timeout ]; then
-              echo "WARNING: VMI did not reach Running phase after ${timeout}s (current: $PHASE)"
-              echo "VM was created but may still be starting"
-              break
+              echo "ERROR: VMI did not reach Running phase after ${timeout}s (current: $PHASE)"
+              echo "--- VMI details ---"
+              oc get vmi "$VM_NAME" -n "$NAMESPACE" -o yaml 2>&1 || true
+              echo "--- Recent events ---"
+              oc get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>&1 | tail -20 || true
+              exit 1
             fi
             if [ $((elapsed % 30)) -eq 0 ] && [ $elapsed -gt 0 ]; then
               echo "Waiting for VMI (phase: ${PHASE:-Pending}, ${elapsed}s)..."

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -32,6 +32,12 @@ spec:
         value: "vCurrent"
       - name: additional-enabled-capabilities
         value: ""
+      - name: install-virt
+        value: "false"
+      - name: vm-os
+        value: "rhel9"
+      - name: virt-node-dedicated
+        value: "false"
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -50,12 +50,27 @@ spec:
     - name: credentials
       secret:
         secretName: openshift-4-gcp-service-account
+    - name: registry-pull-secret
+      secret:
+        secretName: infra-image-registry-pull-secret
 
   templates:
     - name: start
       steps:
         - - name: create
             template: create
+
+        - - name: add-virt-node
+            template: add-virt-node
+            when: '{{ "{{" }}workflow.parameters.install-virt{{ "}}" }} == true'
+
+        - - name: install-virt-operator
+            template: install-virt-operator
+            when: '{{ "{{" }}workflow.parameters.install-virt{{ "}}" }} == true'
+
+        - - name: create-vm
+            template: create-vm
+            when: '{{ "{{" }}workflow.parameters.install-virt{{ "}}" }} == true'
 
         - - name: gather
             template: gather
@@ -188,6 +203,458 @@ spec:
             path: /data/cluster-console-password
             archive:
               none: {}
+
+    - name: add-virt-node
+      activeDeadlineSeconds: 900
+      script:
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-{{ .Chart.Annotations.automationFlavorsVersion }}
+        command: [bash]
+        source: |
+          set -euo pipefail
+          export KUBECONFIG=/data/auth/kubeconfig
+
+          DEDICATED='{{ "{{" }}workflow.parameters.virt-node-dedicated{{ "}}" }}'
+
+          echo "=== Creating dedicated virt worker MachineSet ==="
+          echo "Dedicated (tainted) mode: $DEDICATED"
+
+          # Pick a worker MachineSet deterministically so multi-zone clusters behave predictably
+          WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json | jq -r '
+            .items
+            | map(select(
+                .metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker" or
+                .metadata.labels["machine.openshift.io/cluster-api-machine-type"] == "worker"
+              ))
+            | sort_by(.metadata.name)
+            | .[0].metadata.name // empty
+          ')
+          if [ -z "$WORKER_MS" ]; then
+            echo "ERROR: No worker MachineSet found in openshift-machine-api"
+            exit 1
+          fi
+          echo "Using $WORKER_MS as template"
+
+          # Extract infrastructure ID and zone
+          INFRA_ID=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
+          ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
+          REGION=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.region}')
+          PROJECT_ID=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.projectID}')
+
+          echo "Infra ID: $INFRA_ID, Zone: $ZONE, Region: $REGION, Project: $PROJECT_ID"
+
+          VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
+
+          # Check if it already exists
+          if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
+            echo "MachineSet $VIRT_MS_NAME already exists"
+          else
+            # Build jq filter — optionally add taint
+            JQ_FILTER='
+              del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
+              .metadata.name = $name |
+              .spec.replicas = 1 |
+              .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
+              .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
+              .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
+              .spec.template.spec.providerSpec.value.machineType = $machineType |
+              .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
+            '
+            if [ "$DEDICATED" = "true" ]; then
+              JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
+            fi
+
+            # Export the existing MachineSet and modify it
+            oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
+              jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
+              oc apply -f -
+            echo "Created MachineSet $VIRT_MS_NAME"
+          fi
+
+          # Wait for the machine to be provisioned and node to be Ready
+          echo "Waiting for virt node to become Ready..."
+          timeout=600
+          elapsed=0
+          while true; do
+            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Ready")].status=="True")].metadata.name}' 2>/dev/null || echo "")
+            if [ -n "$READY_NODES" ]; then
+              echo "Virt node is Ready: $READY_NODES"
+              break
+            fi
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timeout waiting for virt node after ${timeout}s"
+              oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machineset="$VIRT_MS_NAME"
+              exit 1
+            fi
+            if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+              echo "Still waiting... (${elapsed}s elapsed)"
+              oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machineset="$VIRT_MS_NAME" --no-headers 2>/dev/null || true
+            fi
+            sleep 15
+            elapsed=$((elapsed + 15))
+          done
+
+          echo "=== Virt worker node ready ==="
+        volumeMounts:
+          - name: data
+            mountPath: /data
+
+    - name: install-virt-operator
+      activeDeadlineSeconds: 2400
+      script:
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-{{ .Chart.Annotations.automationFlavorsVersion }}
+        command: [bash]
+        source: |
+          set -euo pipefail
+          export KUBECONFIG=/data/auth/kubeconfig
+
+          OLM_NAMESPACE="openshift-cnv"
+          SUBSCRIPTION_NAME="kubevirt-hyperconverged"
+          HCO_NAMESPACE="$OLM_NAMESPACE"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          echo "=== Installing OpenShift Virtualization ==="
+
+          # Check if already installed and healthy
+          if oc get hyperconverged "$HCO_NAME" -n "$HCO_NAMESPACE" &>/dev/null; then
+            avail=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "Unknown")
+            prog=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Progressing")].status}' 2>/dev/null || echo "Unknown")
+            degr=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Degraded")].status}' 2>/dev/null || echo "Unknown")
+            if [ "$avail" = "True" ] && [ "$prog" = "False" ] && [ "$degr" = "False" ]; then
+              echo "OpenShift Virtualization already installed and healthy"
+              echo "Ensuring VSOCK and KVM_EMULATION are configured..."
+            else
+              echo "HyperConverged exists but not healthy (Available=$avail, Progressing=$prog, Degraded=$degr)"
+            fi
+          fi
+
+          # Create namespace, OperatorGroup, and Subscription
+          cat <<'EOFK8S' | oc apply -f -
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: openshift-cnv
+          ---
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: openshift-cnv
+            namespace: openshift-cnv
+          spec:
+            targetNamespaces:
+            - openshift-cnv
+          ---
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: kubevirt-hyperconverged
+            namespace: openshift-cnv
+          spec:
+            channel: stable
+            name: kubevirt-hyperconverged
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+            installPlanApproval: Automatic
+          EOFK8S
+          echo "Applied namespace, OperatorGroup, and Subscription"
+
+          # Wait for installedCSV
+          echo "Waiting for Subscription to report installedCSV..."
+          timeout=300
+          elapsed=0
+          until oc -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" -o jsonpath='{.status.installedCSV}' 2>/dev/null | grep -q .; do
+            sleep 5
+            elapsed=$((elapsed + 5))
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timeout waiting for installedCSV after ${timeout}s"
+              exit 1
+            fi
+            if [ $((elapsed % 30)) -eq 0 ]; then
+              echo "Still waiting for installedCSV... (${elapsed}s)"
+            fi
+          done
+
+          CSV=$(oc -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" -o jsonpath='{.status.installedCSV}')
+          echo "InstalledCSV: $CSV"
+
+          # Wait for CSV Succeeded
+          echo "Waiting for CSV to reach Succeeded phase..."
+          timeout=900
+          elapsed=0
+          while true; do
+            PHASE=$(oc -n "$OLM_NAMESPACE" get csv "$CSV" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+            if [ "$PHASE" = "Succeeded" ]; then
+              echo "CSV is Succeeded"
+              break
+            fi
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: CSV did not reach Succeeded (current: $PHASE) after ${timeout}s"
+              exit 1
+            fi
+            if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+              echo "Still waiting for CSV (Phase: ${PHASE:-Unknown}, ${elapsed}s)..."
+            fi
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          # Create HyperConverged CR with VSOCK
+          echo "Creating HyperConverged CR with VSOCK feature gate..."
+          cat <<EOFHCO | oc apply -f -
+          apiVersion: hco.kubevirt.io/v1beta1
+          kind: HyperConverged
+          metadata:
+            name: ${HCO_NAME}
+            namespace: ${HCO_NAMESPACE}
+            annotations:
+              kubevirt.kubevirt.io/jsonpatch: |-
+                [
+                  {
+                    "op":"add",
+                    "path":"/spec/configuration/developerConfiguration/featureGates/-",
+                    "value":"VSOCK"
+                  }
+                ]
+          spec: {}
+          EOFHCO
+          echo "Applied HyperConverged CR"
+
+          # Wait for HyperConverged to become healthy
+          echo "Waiting for HyperConverged to become healthy..."
+          timeout=1800
+          elapsed=0
+          while true; do
+            avail=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "Unknown")
+            prog=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Progressing")].status}' 2>/dev/null || echo "Unknown")
+            degr=$(oc -n "$HCO_NAMESPACE" get hyperconverged "$HCO_NAME" -o jsonpath='{.status.conditions[?(@.type=="Degraded")].status}' 2>/dev/null || echo "Unknown")
+            if [ "$avail" = "True" ] && [ "$prog" = "False" ] && [ "$degr" = "False" ]; then
+              echo "HyperConverged is healthy"
+              break
+            fi
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: HyperConverged not healthy after ${timeout}s (Available=$avail, Progressing=$prog, Degraded=$degr)"
+              exit 1
+            fi
+            if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+              echo "Still waiting (Available=$avail, Progressing=$prog, Degraded=$degr) - ${elapsed}s"
+            fi
+            sleep 15
+            elapsed=$((elapsed + 15))
+          done
+
+          # Patch KVM_EMULATION
+          current_kvm=$(oc get subscription kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.spec.config.env[?(@.name=="KVM_EMULATION")].value}' 2>/dev/null || echo "")
+          if [ "$current_kvm" = "true" ]; then
+            echo "KVM_EMULATION already set"
+          else
+            echo "Patching subscription with KVM_EMULATION..."
+            oc patch subscription kubevirt-hyperconverged \
+              -n openshift-cnv \
+              --type=merge \
+              -p '{"spec":{"config":{"selector":{"matchLabels":{"name":"hyperconverged-cluster-operator"}},"env":[{"name":"KVM_EMULATION","value":"true"}]}}}'
+            echo "KVM_EMULATION patched"
+          fi
+
+          echo "=== OpenShift Virtualization installed with VSOCK + KVM_EMULATION ==="
+        volumeMounts:
+          - name: data
+            mountPath: /data
+
+    - name: create-vm
+      activeDeadlineSeconds: 600
+      outputs:
+        artifacts:
+          - name: vm-access
+            path: /data/vm-access.md
+            archive:
+              none: {}
+      script:
+        image: quay.io/stackrox-io/ci:automation-flavors-openshift-4-{{ .Chart.Annotations.automationFlavorsVersion }}
+        command: [bash]
+        source: |
+          set -euo pipefail
+          export KUBECONFIG=/data/auth/kubeconfig
+
+          VM_OS='{{ "{{" }}workflow.parameters.vm-os{{ "}}" }}'
+          DEDICATED='{{ "{{" }}workflow.parameters.virt-node-dedicated{{ "}}" }}'
+          NAMESPACE="openshift-cnv"
+          VM_NAME="${VM_OS}-1"
+          CONTAINER_IMAGE="quay.io/rhacs-eng/vm-images:${VM_OS}-dnf-primed-latest"
+          SSH_USER="cloud-user"
+          PULL_SECRET_NAME="quay-rhacs-eng-ro"
+
+          case "$VM_OS" in
+            rhel9|rhel10) ;;
+            *)
+              echo "ERROR: unsupported vm-os '$VM_OS'. Valid values: rhel9, rhel10."
+              exit 1
+              ;;
+          esac
+
+          VM_PASSWORD=$(openssl rand -hex 10)
+
+          echo "=== Creating VM: $VM_NAME (OS: $VM_OS, dedicated=$DEDICATED) ==="
+
+          # Copy the already-provisioned Quay pull secret from the infra namespace into the target cluster
+          echo "Creating pull secret for quay.io/rhacs-eng in namespace $NAMESPACE from mounted infra secret..."
+          if [ ! -s /infra-secrets/quay/.dockerconfigjson ]; then
+            echo "ERROR: mounted registry secret /infra-secrets/quay/.dockerconfigjson is missing or empty"
+            exit 1
+          fi
+          cat <<EOFSECRET | oc apply -f -
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${PULL_SECRET_NAME}
+            namespace: ${NAMESPACE}
+          type: kubernetes.io/dockerconfigjson
+          data:
+            .dockerconfigjson: $(base64 < /infra-secrets/quay/.dockerconfigjson | tr -d '\n')
+          EOFSECRET
+          echo "Pull secret created"
+
+          # Check if VM already exists
+          if oc get vm "$VM_NAME" -n "$NAMESPACE" &>/dev/null; then
+            STATUS=$(oc get vm "$VM_NAME" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
+            echo "VM $VM_NAME already exists (status: $STATUS)"
+            if [ "$STATUS" = "Running" ]; then
+              echo "VM is already running"
+              exit 0
+            fi
+          fi
+
+          # Build node placement YAML fragment conditionally
+          NODE_PLACEMENT=""
+          if [ "$DEDICATED" = "true" ]; then
+            NODE_PLACEMENT='
+                nodeSelector:
+                  node-role.kubernetes.io/virt: ""
+                tolerations:
+                  - key: "node-role.kubernetes.io/virt"
+                    operator: "Exists"
+                    effect: "NoSchedule"'
+          fi
+
+          cat <<EOFVM | oc apply -f -
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: ${VM_NAME}
+            namespace: ${NAMESPACE}
+          spec:
+            runStrategy: Always
+            template:
+              metadata:
+                labels:
+                  kubevirt.io/size: small
+                  kubevirt.io/domain: ${VM_NAME}
+              spec:${NODE_PLACEMENT}
+                domain:
+                  cpu:
+                    cores: 2
+                    sockets: 1
+                    threads: 1
+                  devices:
+                    autoattachVSOCK: true
+                    disks:
+                      - name: containerdisk
+                        bootOrder: 1
+                        disk:
+                          bus: virtio
+                      - name: cloudinitdisk
+                        bootOrder: 2
+                        disk:
+                          bus: virtio
+                    interfaces:
+                    - name: default
+                      masquerade: {}
+                  memory:
+                    guest: 4Gi
+                  resources:
+                    requests:
+                      memory: 4Gi
+                      cpu: "2"
+                networks:
+                - name: default
+                  pod: {}
+                volumes:
+                  - name: containerdisk
+                    containerDisk:
+                      image: ${CONTAINER_IMAGE}
+                      imagePullSecret: ${PULL_SECRET_NAME}
+                  - name: cloudinitdisk
+                    cloudInitNoCloud:
+                      userData: |
+                        #cloud-config
+                        user: ${SSH_USER}
+                        password: ${VM_PASSWORD}
+                        chpasswd: { expire: False }
+                        ssh_pwauth: True
+          EOFVM
+          echo "VM $VM_NAME created"
+
+          # Wait for VMI to be ready
+          echo "Waiting for VMI $VM_NAME to be ready..."
+          timeout=300
+          elapsed=0
+          while true; do
+            PHASE=$(oc get vmi "$VM_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+            if [ "$PHASE" = "Running" ]; then
+              echo "VMI is Running"
+              break
+            fi
+            if [ $elapsed -ge $timeout ]; then
+              echo "WARNING: VMI did not reach Running phase after ${timeout}s (current: $PHASE)"
+              echo "VM was created but may still be starting"
+              break
+            fi
+            if [ $((elapsed % 30)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+              echo "Waiting for VMI (phase: ${PHASE:-Pending}, ${elapsed}s)..."
+            fi
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo ""
+          echo "=== VM Created ==="
+          echo "  Name: $VM_NAME"
+          echo "  Namespace: $NAMESPACE"
+          echo "  OS: $VM_OS"
+          echo "  User: $SSH_USER"
+          echo "  Password: stored in vm-access artifact"
+          echo "  VSOCK: enabled"
+          echo ""
+          echo "Access via: virtctl ssh -n $NAMESPACE ${SSH_USER}@vmi/${VM_NAME}"
+
+          # Save VM access info to the downloadable artifact
+          umask 077
+          cat > /data/vm-access.md <<EOFMD
+          # VM Access Information
+
+          - **VM Name:** $VM_NAME
+          - **Namespace:** $NAMESPACE
+          - **OS:** $VM_OS
+          - **Username:** $SSH_USER
+          - **Password:** $VM_PASSWORD
+          - **VSOCK:** enabled
+
+          ## SSH Access
+
+          \`\`\`bash
+          virtctl ssh -n $NAMESPACE ${SSH_USER}@vmi/${VM_NAME}
+          \`\`\`
+
+          ## Check VM Status
+
+          \`\`\`bash
+          oc get vm,vmi -n $NAMESPACE
+          \`\`\`
+          EOFMD
+        volumeMounts:
+          - name: data
+            mountPath: /data
+          - name: registry-pull-secret
+            mountPath: /infra-secrets/quay
+            readOnly: true
 
     - name: wait
       suspend: {}

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -214,12 +214,21 @@ spec:
           export KUBECONFIG=/data/auth/kubeconfig
 
           DEDICATED='{{ "{{" }}workflow.parameters.virt-node-dedicated{{ "}}" }}'
+          INFRA_ID=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
 
-          echo "=== Creating dedicated virt worker MachineSet ==="
+          echo "=== Creating dedicated virt worker node ==="
           echo "Dedicated (tainted) mode: $DEDICATED"
+          echo "Infrastructure ID: $INFRA_ID"
 
-          # Pick a worker MachineSet deterministically so multi-zone clusters behave predictably
-          WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json | jq -r '
+          READY_VIRT=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | \
+            jq '[.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length' || echo "0")
+          if [ "${READY_VIRT:-0}" -gt 0 ]; then
+            echo "Virt node already exists and is Ready"
+            oc get nodes -l node-role.kubernetes.io/virt
+            exit 0
+          fi
+
+          WORKER_MS=$(oc get machinesets -n openshift-machine-api -o json 2>/dev/null | jq -r '
             .items
             | map(select(
                 .metadata.labels["machine.openshift.io/cluster-api-machine-role"] == "worker" or
@@ -227,71 +236,221 @@ spec:
               ))
             | sort_by(.metadata.name)
             | .[0].metadata.name // empty
-          ')
-          if [ -z "$WORKER_MS" ]; then
-            echo "ERROR: No worker MachineSet found in openshift-machine-api"
-            exit 1
-          fi
-          echo "Using $WORKER_MS as template"
+          ' 2>/dev/null || echo "")
 
-          # Extract infrastructure ID and zone
-          INFRA_ID=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
-          ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
-          REGION=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.region}')
-          PROJECT_ID=$(oc get machineset "$WORKER_MS" -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.projectID}')
+          CREATED_VIA=""
 
-          echo "Infra ID: $INFRA_ID, Zone: $ZONE, Region: $REGION, Project: $PROJECT_ID"
+          if [ -n "$WORKER_MS" ]; then
+            # ── Legacy path: clone MachineSet in openshift-machine-api ──
+            echo "Using legacy MachineSet path (source: $WORKER_MS)"
+            ZONE=$(oc get machineset "$WORKER_MS" -n openshift-machine-api \
+              -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
+            VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
+            CREATED_VIA="legacy"
 
-          VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE}"
+            if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
+              echo "MachineSet $VIRT_MS_NAME already exists"
+            else
+              JQ_FILTER='
+                del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
+                .metadata.name = $name |
+                .spec.replicas = 1 |
+                .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
+                .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
+                .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
+                .spec.template.spec.providerSpec.value.machineType = $machineType |
+                .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
+              '
+              if [ "$DEDICATED" = "true" ]; then
+                JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
+              fi
 
-          # Check if it already exists
-          if oc get machineset "$VIRT_MS_NAME" -n openshift-machine-api &>/dev/null; then
-            echo "MachineSet $VIRT_MS_NAME already exists"
-          else
-            # Build jq filter — optionally add taint
-            JQ_FILTER='
-              del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.generation, .status) |
-              .metadata.name = $name |
-              .spec.replicas = 1 |
-              .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
-              .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
-              .spec.template.metadata.labels["node-role.kubernetes.io/virt"] = "" |
-              .spec.template.spec.providerSpec.value.machineType = $machineType |
-              .spec.template.spec.metadata.labels["node-role.kubernetes.io/virt"] = ""
-            '
-            if [ "$DEDICATED" = "true" ]; then
-              JQ_FILTER="${JQ_FILTER} | .spec.template.spec.taints = [{\"key\": \"node-role.kubernetes.io/virt\", \"effect\": \"NoSchedule\"}]"
+              oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
+                jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
+                oc apply -f -
+              echo "Created MachineSet $VIRT_MS_NAME"
             fi
 
-            # Export the existing MachineSet and modify it
-            oc get machineset "$WORKER_MS" -n openshift-machine-api -o json | \
-              jq --arg name "$VIRT_MS_NAME" --arg machineType "n2-standard-8" "$JQ_FILTER" | \
-              oc apply -f -
-            echo "Created MachineSet $VIRT_MS_NAME"
+          else
+            # ── CAPI path: GCPMachineTemplate + MachineSet in openshift-cluster-api-guests ──
+            echo "No legacy MachineSets found, using Cluster API path"
+            CAPI_NS="openshift-cluster-api-guests"
+            CREATED_VIA="capi"
+
+            CLUSTER_NAME=$(oc get clusters.cluster.x-k8s.io -n "$CAPI_NS" \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+            if [ -z "$CLUSTER_NAME" ]; then
+              echo "ERROR: No CAPI Cluster found in $CAPI_NS"
+              echo "Neither legacy MachineSets nor CAPI resources are available"
+              exit 1
+            fi
+            echo "CAPI Cluster: $CLUSTER_NAME"
+
+            WORKER_GCP_MACHINE=$(oc get gcpmachines.infrastructure.cluster.x-k8s.io \
+              -n "$CAPI_NS" -o json | jq -r '
+              [.items[] | select(.metadata.name | test("worker"))]
+              | sort_by(.metadata.name)
+              | .[0].metadata.name // empty
+            ')
+            if [ -z "$WORKER_GCP_MACHINE" ]; then
+              echo "ERROR: No worker GCPMachine found in $CAPI_NS"
+              oc get gcpmachines.infrastructure.cluster.x-k8s.io -n "$CAPI_NS" \
+                --no-headers 2>/dev/null || true
+              exit 1
+            fi
+            echo "Source GCPMachine: $WORKER_GCP_MACHINE"
+
+            GCP_SPEC=$(oc get gcpmachines.infrastructure.cluster.x-k8s.io \
+              "$WORKER_GCP_MACHINE" -n "$CAPI_NS" -o json | jq '.spec')
+            ZONE=$(echo "$GCP_SPEC" | jq -r '.zone // .failureDomain // empty')
+            echo "Zone: $ZONE"
+
+            VIRT_TEMPLATE_NAME="${INFRA_ID}-virt-worker"
+            VIRT_MS_NAME="${INFRA_ID}-virt-worker-${ZONE:-a}"
+
+            WORKER_MACHINE=$(oc get machines.cluster.x-k8s.io -n "$CAPI_NS" -o json | jq -r '
+              [.items[] | select(.metadata.name | test("worker"))]
+              | sort_by(.metadata.name)
+              | .[0].metadata.name // empty
+            ')
+            BOOTSTRAP_SECRET=$(oc get machines.cluster.x-k8s.io "$WORKER_MACHINE" \
+              -n "$CAPI_NS" -o jsonpath='{.spec.bootstrap.dataSecretName}' 2>/dev/null || echo "")
+            if [ -z "$BOOTSTRAP_SECRET" ]; then
+              BOOTSTRAP_SECRET="${INFRA_ID}-worker"
+              echo "Bootstrap secret not found on Machine, using convention: $BOOTSTRAP_SECRET"
+            else
+              echo "Bootstrap secret: $BOOTSTRAP_SECRET"
+            fi
+
+            if oc get machinesets.cluster.x-k8s.io "$VIRT_MS_NAME" -n "$CAPI_NS" &>/dev/null; then
+              echo "CAPI MachineSet $VIRT_MS_NAME already exists"
+            else
+              echo "$GCP_SPEC" | jq \
+                --arg name "$VIRT_TEMPLATE_NAME" --arg ns "$CAPI_NS" '{
+                apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+                kind: "GCPMachineTemplate",
+                metadata: { name: $name, namespace: $ns },
+                spec: { template: { spec: (. | del(.providerID, .providerStatus) |
+                  if has("instanceType") then .instanceType = "n2-standard-8"
+                  elif has("machineType") then .machineType = "n2-standard-8"
+                  else . + {instanceType: "n2-standard-8"}
+                  end
+                )}}
+              }' | oc apply -f -
+              echo "Created GCPMachineTemplate $VIRT_TEMPLATE_NAME"
+
+              jq -n \
+                --arg name "$VIRT_MS_NAME" \
+                --arg ns "$CAPI_NS" \
+                --arg cluster "$CLUSTER_NAME" \
+                --arg tmpl "$VIRT_TEMPLATE_NAME" \
+                --arg boot "$BOOTSTRAP_SECRET" \
+              '{
+                apiVersion: "cluster.x-k8s.io/v1beta1",
+                kind: "MachineSet",
+                metadata: {
+                  name: $name,
+                  namespace: $ns,
+                  labels: { "cluster.x-k8s.io/cluster-name": $cluster }
+                },
+                spec: {
+                  clusterName: $cluster,
+                  replicas: 1,
+                  selector: {
+                    matchLabels: {
+                      "cluster.x-k8s.io/cluster-name": $cluster,
+                      "cluster.x-k8s.io/set-name": $name
+                    }
+                  },
+                  template: {
+                    metadata: {
+                      labels: {
+                        "cluster.x-k8s.io/cluster-name": $cluster,
+                        "cluster.x-k8s.io/set-name": $name,
+                        "node-role.kubernetes.io/worker": "",
+                        "node-role.kubernetes.io/virt": ""
+                      }
+                    },
+                    spec: {
+                      clusterName: $cluster,
+                      bootstrap: { dataSecretName: $boot },
+                      infrastructureRef: {
+                        apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+                        kind: "GCPMachineTemplate",
+                        name: $tmpl
+                      }
+                    }
+                  }
+                }
+              }' | oc apply -f -
+              echo "Created CAPI MachineSet $VIRT_MS_NAME"
+            fi
           fi
 
-          # Wait for the machine to be provisioned and node to be Ready
           echo "Waiting for virt node to become Ready..."
           timeout=600
           elapsed=0
           while true; do
-            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | jq -r '[.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True")) | .metadata.name] | join(" ")' 2>/dev/null || echo "")
+            READY_NODES=$(oc get nodes -l node-role.kubernetes.io/virt -o json 2>/dev/null | \
+              jq -r '[.items[] | select(.status.conditions[]? |
+                select(.type=="Ready" and .status=="True")) |
+                .metadata.name] | join(" ")' 2>/dev/null || echo "")
             if [ -n "$READY_NODES" ]; then
               echo "Virt node is Ready: $READY_NODES"
               break
             fi
+
+            if [ "$CREATED_VIA" = "capi" ] && [ $elapsed -ge 120 ]; then
+              CAPI_NODE=$(oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
+                -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
+                -o jsonpath='{.items[0].status.nodeRef.name}' 2>/dev/null || echo "")
+              if [ -n "$CAPI_NODE" ]; then
+                NODE_READY=$(oc get node "$CAPI_NODE" \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+                if [ "$NODE_READY" = "True" ]; then
+                  echo "CAPI node $CAPI_NODE is Ready, applying virt label"
+                  oc label node "$CAPI_NODE" node-role.kubernetes.io/virt= --overwrite
+                  READY_NODES="$CAPI_NODE"
+                  break
+                fi
+              fi
+            fi
+
             if [ $elapsed -ge $timeout ]; then
               echo "ERROR: Timeout waiting for virt node after ${timeout}s"
-              oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machineset="$VIRT_MS_NAME"
+              if [ "$CREATED_VIA" = "legacy" ]; then
+                oc get machines -n openshift-machine-api \
+                  -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
+                  --no-headers 2>/dev/null || true
+              else
+                oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
+                  -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
+                  --no-headers 2>/dev/null || true
+              fi
               exit 1
             fi
             if [ $((elapsed % 60)) -eq 0 ] && [ $elapsed -gt 0 ]; then
               echo "Still waiting... (${elapsed}s elapsed)"
-              oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machineset="$VIRT_MS_NAME" --no-headers 2>/dev/null || true
+              if [ "$CREATED_VIA" = "legacy" ]; then
+                oc get machines -n openshift-machine-api \
+                  -l "machine.openshift.io/cluster-api-machineset=$VIRT_MS_NAME" \
+                  --no-headers 2>/dev/null || true
+              else
+                oc get machines.cluster.x-k8s.io -n "$CAPI_NS" \
+                  -l "cluster.x-k8s.io/set-name=$VIRT_MS_NAME" \
+                  --no-headers 2>/dev/null || true
+              fi
             fi
             sleep 15
             elapsed=$((elapsed + 15))
           done
+
+          if [ "$DEDICATED" = "true" ] && [ "$CREATED_VIA" = "capi" ]; then
+            VIRT_NODE=$(echo "$READY_NODES" | awk '{print $1}')
+            echo "Applying NoSchedule taint to $VIRT_NODE (CAPI path)"
+            oc adm taint nodes "$VIRT_NODE" \
+              node-role.kubernetes.io/virt=:NoSchedule --overwrite
+          fi
 
           echo "=== Virt worker node ready ==="
         volumeMounts:


### PR DESCRIPTION
Add `install-virt`, `vm-os`, and `virt-node-dedicated` parameters to the `openshift-4` (and `openshift-4-perf-scale`) flavor so users can optionally get a cluster with OpenShift Virtualization, a dedicated virt worker node, and a downloadable VM access artifact.

When `install-virt=true`, three conditional post-install steps run after cluster creation:

1. **add-virt-node** — scales up an existing worker MachineSet by 1, waits for the new node to become Ready, then labels it `node-role.kubernetes.io/virt` (optionally tainted when `virt-node-dedicated=true`)
2. **install-virt-operator** — installs OpenShift Virtualization via OLM with VSOCK and KVM_EMULATION enabled
3. **create-vm** — deploys a VM from `quay.io/rhacs-eng/vm-images` using the selected `vm-os` (rhel9 or rhel10), generates a random password, and writes a downloadable `vm-access` artifact with SSH credentials

When `install-virt=false` (the default), existing behavior is unchanged.

> **Note:** For best VM performance, use `n2` worker nodes (`worker-node-type=n2-standard-8`). On default `e2` instances, `KVM_EMULATION` is used as a fallback (slower but functional).

⚠️ See also https://github.com/stackrox/stackrox/pull/21060 where we add a GH action to add VMs to an existing cluster. However, there is no guarantee that the nodes in that cluster would support KVM.

## Usage examples

```bash
# With virt (shared node, n2 recommended)
infractl create openshift-4 my-virt-cluster \
  --arg install-virt=true \
  --arg vm-os=rhel9 \
  --arg worker-node-type=n2-standard-8 \
  --lifespan 8h

# With virt (dedicated, tainted node)
infractl create openshift-4 my-virt-dedicated \
  --arg install-virt=true \
  --arg vm-os=rhel9 \
  --arg virt-node-dedicated=true \
  --arg worker-node-type=n2-standard-8 \
  --lifespan 8h

# Without virt (default, unchanged behavior)
infractl create openshift-4 my-cluster --lifespan 4h
```

## How I validated my change

- [x] Unit tests
- [x] Parameter parity validation (`CheckWorkflowEquivalence`): extracted workflow and flavor parameter names, diffed — both `openshift-4` and `openshift-4-perf-scale` match
- [ ] E2E: create a cluster with `install-virt=true` and verify the virt node, operator, and VM are running, and the `vm-access` artifact is downloadable

AI-Assisted: cursor, ~90% generated from Superpowers implementation plan, user reviewed the plan twice.