### PR TITLE
ROX-35059: create shared master and worker service accounts

### DIFF
--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -264,6 +264,13 @@
       value: 3
       kind: optional
 
+    - name: master-node-service-account
+      description: GCP service account for master nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-master-node@acs-team-temp-dev.iam.gserviceaccount.com
+      kind: optional
+
     - name: worker-node-type
       description: the type of worker nodes
       value: e2-standard-8
@@ -272,6 +279,13 @@
     - name: worker-node-count
       description: number of worker nodes
       value: 3
+      kind: optional
+
+    - name: worker-node-service-account
+      description: GCP service account for worker nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-worker-node@acs-team-temp-dev.iam.gserviceaccount.com
       kind: optional
 
     - name: region
@@ -470,6 +484,20 @@
         Consult OCP documentation for details. {{ .Chart.Annotations.ocpCredentialsMode }} is the value used by
         stackrox CI.
 
+    - name: master-node-service-account
+      description: GCP service account for master nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-master-node@acs-team-temp-dev.iam.gserviceaccount.com
+      kind: optional
+
+    - name: worker-node-service-account
+      description: GCP service account for worker nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-worker-node@acs-team-temp-dev.iam.gserviceaccount.com
+      kind: optional
+
     - name: region
       description: Google Cloud region to deploy infrastructure into.
       value: us-east1
@@ -591,9 +619,23 @@
       value: n1-standard-8
       kind: optional
 
+    - name: master-node-service-account
+      description: GCP service account for master nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-master-node@acs-team-temp-dev.iam.gserviceaccount.com
+      kind: optional
+
     - name: worker-node-count
       description: number of worker nodes
       value: 9
+      kind: optional
+
+    - name: worker-node-service-account
+      description: GCP service account for worker nodes
+      help: |
+        Leave empty to let the OpenShift installer create a dedicated service account.
+      value: openshift-worker-node@acs-team-temp-dev.iam.gserviceaccount.com
       kind: optional
 
     - name: region

--- a/chart/infra-server/static/workflow-openshift-4-demo.yaml
+++ b/chart/infra-server/static/workflow-openshift-4-demo.yaml
@@ -20,6 +20,8 @@ spec:
       - name: secured-cluster-services-helm-chart-version
       - name: trusted-certs-enabled
       - name: credentials-mode
+      - name: master-node-service-account
+      - name: worker-node-service-account
       - name: region
       - name: ssd-storage-class
       - name: baseline-capability-set
@@ -120,6 +122,10 @@ spec:
             value: "n1-standard-4"
           - name: WORKER_NODE_TYPE
             value: "e2-standard-16"
+          - name: MASTER_NODE_SERVICE_ACCOUNT
+            value: '{{ "{{" }}workflow.parameters.master-node-service-account{{ "}}" }}'
+          - name: WORKER_NODE_SERVICE_ACCOUNT
+            value: '{{ "{{" }}workflow.parameters.worker-node-service-account{{ "}}" }}'
           - name: REGION
             value: '{{ "{{" }}workflow.parameters.region{{ "}}" }}'
           - name: TRUSTED_CERTS_ENABLED

--- a/chart/infra-server/static/workflow-openshift-4.yaml
+++ b/chart/infra-server/static/workflow-openshift-4.yaml
@@ -14,10 +14,12 @@ spec:
         value: ""
       - name: master-node-count
         value: ""
+      - name: master-node-service-account
       - name: worker-node-type
         value: ""
       - name: worker-node-count
         value: ""
+      - name: worker-node-service-account
       - name: region
         value: ""
       - name: pull-secret
@@ -131,8 +133,12 @@ spec:
             value: '{{ "{{" }}workflow.parameters.worker-node-count{{ "}}" }}'
           - name: MASTER_NODE_TYPE
             value: '{{ "{{" }}workflow.parameters.master-node-type{{ "}}" }}'
+          - name: MASTER_NODE_SERVICE_ACCOUNT
+            value: '{{ "{{" }}workflow.parameters.master-node-service-account{{ "}}" }}'
           - name: WORKER_NODE_TYPE
             value: '{{ "{{" }}workflow.parameters.worker-node-type{{ "}}" }}'
+          - name: WORKER_NODE_SERVICE_ACCOUNT
+            value: '{{ "{{" }}workflow.parameters.worker-node-service-account{{ "}}" }}'
           - name: REGION
             value: '{{ "{{" }}workflow.parameters.region{{ "}}" }}'
           - name: FIPS_ENABLED


### PR DESCRIPTION
Add `master-node-service-account` and `worker-node-service-account` parameters to `openshift-4`, `openshift-4-demo`, and `openshift-4-perf-scale` flavors and their workflow templates.