### PR TITLE
chore: Bump version for automation-flavors#348

### DIFF
--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.11.1
-  automationFlavorsVersion: 0.15.1-23-g15dbc7fdac-snapshot
+  automationFlavorsVersion: 0.15.3
   ocpCredentialsMode: Passthrough
 dependencies:
   - name: argo-workflows

--- a/chart/infra-server/Chart.yaml
+++ b/chart/infra-server/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/stackrox/infra
 annotations:
   acsDemoVersion: 4.11.1
-  automationFlavorsVersion: 0.15.2
+  automationFlavorsVersion: 0.15.1-23-g15dbc7fdac-snapshot
   ocpCredentialsMode: Passthrough
 dependencies:
   - name: argo-workflows

--- a/chart/infra-server/static/flavors.yaml
+++ b/chart/infra-server/static/flavors.yaml
@@ -23,10 +23,6 @@
       value: default
       kind: hardcoded
 
-    - name: enable-psps
-      value: "false"
-      kind: hardcoded
-
     - name: gcp-region
       description: GCP region
       help: GCP region to deploy infrastructure into.
@@ -99,12 +95,6 @@
       description: kubernetes version
       value: default
       kind: optional
-
-    - name: enable-psps
-      description: Enable PodSecurityPolicy generation
-      value: "false"
-      kind: optional
-      help: PSPs were removed from K8s >=1.25. Enabling PSP generation on newer K8s versions will fail the deployment.
 
     - name: gcp-region
       description: GCP region

--- a/chart/infra-server/static/workflow-demo.yaml
+++ b/chart/infra-server/static/workflow-demo.yaml
@@ -17,7 +17,6 @@ spec:
       - name: main-image
       - name: central-db-image
       - name: k8s-version
-      - name: enable-psps
       - name: gcp-region
       - name: gcp-zone
 
@@ -133,7 +132,6 @@ spec:
           - --dns-gcp-project=acs-team-temp-dev
           - --creation-source=infra
           - --k8s-version={{ "{{" }}workflow.parameters.k8s-version{{ "}}" }}
-          - --enable-psps={{ "{{" }}workflow.parameters.enable-psps{{ "}}" }}
           - --gcp-region={{ "{{" }}workflow.parameters.gcp-region{{ "}}" }}
           - --gcp-zone={{ "{{" }}workflow.parameters.gcp-zone{{ "}}" }}
         volumeMounts:

--- a/chart/infra-server/static/workflow-qa-demo.yaml
+++ b/chart/infra-server/static/workflow-qa-demo.yaml
@@ -23,8 +23,6 @@ spec:
         value: ""
       - name: k8s-version
         value: ""
-      - name: enable-psps
-        value: ""
       - name: gcp-region
         value: ""
       - name: gcp-zone
@@ -141,7 +139,6 @@ spec:
           - --dns-gcp-project=acs-team-temp-dev
           - --creation-source=infra
           - --k8s-version={{ "{{" }}workflow.parameters.k8s-version{{ "}}" }}
-          - --enable-psps={{ "{{" }}workflow.parameters.enable-psps{{ "}}" }}
           - --gcp-region={{ "{{" }}workflow.parameters.gcp-region{{ "}}" }}
           - --gcp-zone={{ "{{" }}workflow.parameters.gcp-zone{{ "}}" }}
         volumeMounts:


### PR DESCRIPTION
For https://redhat.atlassian.net/browse/ROX-35082
Includes removal of a field gone from automation-flavors.