### PR TITLE
fix: scrape infra and argo-workflows service monitors

### DIFF
--- a/chart/infra-server/templates/monitoring/servicemonitors.yaml
+++ b/chart/infra-server/templates/monitoring/servicemonitors.yaml
@@ -5,6 +5,8 @@ kind: ServiceMonitor
 metadata:
   name: argo-workflows
   namespace: argo
+  labels:
+    release: {{ .Release.Name }}
 spec:
   endpoints:
   - port: metrics
@@ -20,6 +22,8 @@ kind: ServiceMonitor
 metadata:
   name: infra-server
   namespace: infra
+  labels:
+    release: {{ .Release.Name }}
 spec:
   endpoints:
   - port: metrics


### PR DESCRIPTION
Since about April 20, we didn't get any alerts into #acs-infra-alerts.
There are many failed clusters for which we didn't get alerts.
Root cause: Prometheus not scraping the infra and argo-workflows servicemonitors.

Validated on dev.infra.rox.systems