### PR TITLE
fix: add release labels to servicemonitors

### DIFF
--- a/chart/infra-server/templates/monitoring/rules.yaml
+++ b/chart/infra-server/templates/monitoring/rules.yaml
@@ -5,13 +5,15 @@ kind: PrometheusRule
 metadata:
   name: argo-workflow-failures
   namespace: monitoring
+  labels:
+    release: {{ .Release.Name }}
 spec:
   groups:
   - name: Workflow failures
     interval: 30s
     rules:
     - alert: Workflow Error
-      expr: increase(argo_workflows_gauge{status="Error"}[5m]) > 0
+      expr: increase(argo_workflows_gauge{phase="Error"}[5m]) > 0
       for: 1m
       annotations:
         summary: A workflow has errored
@@ -21,7 +23,7 @@ spec:
         namespace: monitoring
         environment: {{ .Values.environment }}
     - alert: Workflow Failure
-      expr: increase(argo_workflows_gauge{status="Failed"}[5m]) > 0
+      expr: increase(argo_workflows_gauge{phase="Failed"}[5m]) > 0
       for: 1m
       annotations:
         summary: A workflow has failed.

--- a/chart/infra-server/templates/monitoring/services.yaml
+++ b/chart/infra-server/templates/monitoring/services.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -30,3 +31,4 @@ spec:
     targetPort: 9101
   selector:
     app.kubernetes.io/name: infra-server
+{{- end }}


### PR DESCRIPTION
Proof: 

<img width="2529" height="473" alt="Screenshot 2026-07-13 at 11 13 58" src="https://github.com/user-attachments/assets/353da951-17c4-4c66-8bc8-b3f59b72577f" />

(deployed to dev.infra.rox.systems and triggered a failed cluster)

Currently, Info level alerts (like cluster failures) are not sent to Slack because of the InfoInhibitor. I think this is fine for now, as we battle with the cluster provisioning issues. 
We should provide more specific alerts for the infra service and argo deployment later.